### PR TITLE
Add push contribution mode to the media sender and core publisher

### DIFF
--- a/adapters/pico_wt/include/moq/pico_wt.h
+++ b/adapters/pico_wt/include/moq/pico_wt.h
@@ -116,6 +116,10 @@ MOQ_API bool moq_pico_wt_conn_is_closed(const moq_pico_wt_conn_t *conn);
  * or conn is NULL. */
 MOQ_API uint64_t moq_pico_wt_conn_close_code(const moq_pico_wt_conn_t *conn);
 
+/* Surface a QUIC CONNECTION_CLOSE into the bridge as a clean close. */
+MOQ_API void moq_pico_wt_conn_notify_transport_closed(
+    moq_pico_wt_conn_t *conn, uint64_t code, uint64_t now_us);
+
 /*
  * Pump session actions into the WT connection. Call after each
  * picoquic event-loop iteration. Returns 0 on success, -1 on fatal.

--- a/adapters/pico_wt/pico_wt_adapter.c
+++ b/adapters/pico_wt/pico_wt_adapter.c
@@ -277,6 +277,13 @@ uint64_t moq_pico_wt_conn_close_code(const moq_pico_wt_conn_t *conn)
     return conn ? moq_transport_bridge_close_code(conn->bridge) : 0;
 }
 
+void moq_pico_wt_conn_notify_transport_closed(moq_pico_wt_conn_t *conn,
+                                              uint64_t code, uint64_t now_us)
+{
+    if (!conn) return;
+    moq_transport_bridge_on_transport_close(conn->bridge, code, now_us);
+}
+
 /* -- Service -------------------------------------------------------- */
 
 int moq_pico_wt_service(moq_pico_wt_conn_t *conn, uint64_t now_us)

--- a/adapters/pico_wt/pico_wt_managed.c
+++ b/adapters/pico_wt/pico_wt_managed.c
@@ -437,6 +437,11 @@ fail:
 }
 
 /* -- Packet-loop callback (network thread) -------------------------- */
+static void client_final_pump(moq_pico_wt_managed_t *m, picoquic_quic_t *quic)
+{
+    if (m->on_pump)
+        (void)m->on_pump(m, picoquic_get_quic_time(quic), m->on_pump_ctx);
+}
 
 static int loop_callback(picoquic_quic_t *quic,
     picoquic_packet_loop_cb_enum cb_mode,
@@ -479,6 +484,7 @@ static int loop_callback(picoquic_quic_t *quic,
         pthread_mutex_lock(&m->mutex);
         if (!m->fatal && !m->closed) { m->fatal = true; m->fatal_code = 0; }
         pthread_mutex_unlock(&m->mutex);
+        client_final_pump(m, quic);
         mark_activity(m);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
@@ -503,6 +509,7 @@ static int loop_callback(picoquic_quic_t *quic,
         m->fatal = true;
         m->fatal_code = moq_transport_bridge_fatal_code(conn->bridge);
         pthread_mutex_unlock(&m->mutex);
+        client_final_pump(m, quic);
         mark_activity(m);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
@@ -523,6 +530,9 @@ static int loop_callback(picoquic_quic_t *quic,
         m->fatal = true;
         m->fatal_code = moq_transport_bridge_fatal_code(conn->bridge);
         pthread_mutex_unlock(&m->mutex);
+        /* The pump earlier in THIS cycle ran before the fatal was latched:
+         * it could not have observed it. One final observing pump. */
+        client_final_pump(m, quic);
         mark_activity(m);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
@@ -544,8 +554,11 @@ static int loop_callback(picoquic_quic_t *quic,
     pthread_mutex_unlock(&m->mutex);
 
     /* Fatal is terminal immediately — there is no clean frame worth
-     * preserving. wait()/wake() are already terminal (m->fatal). */
+     * preserving. wait()/wake() are already terminal (m->fatal). The pump
+     * earlier in this cycle ran before the fatal was cached above, so run
+     * one final observing pump before the loop exits. */
     if (fatal_now) {
+        client_final_pump(m, quic);
         mark_activity(m);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }

--- a/adapters/pico_wt/pico_wt_managed.c
+++ b/adapters/pico_wt/pico_wt_managed.c
@@ -488,6 +488,13 @@ static int loop_callback(picoquic_quic_t *quic,
     if (!conn)
         return 0;
 
+    if (m->cnx &&
+        picoquic_get_cnx_state(m->cnx) == picoquic_state_disconnected &&
+        !moq_pico_wt_conn_is_closed(conn) && !moq_pico_wt_conn_is_fatal(conn)) {
+        moq_pico_wt_conn_notify_transport_closed(
+            conn, 0, picoquic_get_quic_time(quic));
+    }
+
     uint64_t now = picoquic_get_quic_time(quic);
 
     /* service → on_pump → service (all on the network thread). */

--- a/adapters/picoquic/moq_picoquic_threaded.c
+++ b/adapters/picoquic/moq_picoquic_threaded.c
@@ -375,6 +375,12 @@ void moq_pq_threaded_test_arm_service_fatal(moq_pq_threaded_conn_t *c)
 }
 #endif
 
+static void client_final_pump(moq_pq_threaded_t *t, picoquic_quic_t *quic)
+{
+    if (t->on_pump)
+        (void)t->on_pump(t, picoquic_get_quic_time(quic), t->on_pump_ctx);
+}
+
 /* True once a connection should leave iteration: app-closed, service-fatal,
  * bridge-fatal, or cleanly closed by the peer. */
 static bool server_conn_dead(const struct moq_pq_threaded_conn *c)
@@ -737,6 +743,7 @@ static int loop_callback(picoquic_quic_t *quic,
             t->fatal_code = 0;
         }
         pthread_mutex_unlock(&t->mutex);
+        client_final_pump(t, quic);
         mark_activity(t);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
@@ -853,6 +860,7 @@ static int loop_callback(picoquic_quic_t *quic,
                 t->fatal_code = 0;  /* transport/handshake-level failure */
             }
             pthread_mutex_unlock(&t->mutex);
+            client_final_pump(t, quic);
             mark_activity(t);
             return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
         }
@@ -864,6 +872,7 @@ static int loop_callback(picoquic_quic_t *quic,
         t->fatal = true;
         t->fatal_code = moq_pq_conn_fatal_code(t->conn);
         pthread_mutex_unlock(&t->mutex);
+        client_final_pump(t, quic);
         mark_activity(t);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
@@ -884,6 +893,9 @@ static int loop_callback(picoquic_quic_t *quic,
         t->fatal = true;
         t->fatal_code = moq_pq_conn_fatal_code(t->conn);
         pthread_mutex_unlock(&t->mutex);
+        /* The pump earlier in THIS cycle ran before the fatal was latched:
+         * it could not have observed it. One final observing pump. */
+        client_final_pump(t, quic);
         mark_activity(t);
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }

--- a/core/include/moq/publisher.h
+++ b/core/include/moq/publisher.h
@@ -90,6 +90,12 @@ typedef struct moq_pub_callbacks {
     /* Appended: fired when a subscriber updates priority/forward/timeout. */
     void (*on_subscriber_updated)(void *ctx, moq_pub_track_t *track,
                                    const moq_pub_subscribe_update_info_t *info);
+    void (*on_publish_ok)(void *ctx, moq_pub_track_t *track, bool forward);
+    void (*on_publish_error)(void *ctx, moq_pub_track_t *track,
+                              moq_request_error_t error_code);
+    void (*on_publish_forward_changed)(void *ctx, moq_pub_track_t *track,
+                                        bool forward);
+    void (*on_publish_finished)(void *ctx, moq_pub_track_t *track);
 } moq_pub_callbacks_t;
 
 MOQ_API void moq_pub_callbacks_init(moq_pub_callbacks_t *cb);
@@ -188,6 +194,67 @@ MOQ_API moq_result_t moq_pub_remove_track(
     moq_publisher_t *pub,
     moq_pub_track_t *track,
     uint64_t now_us);
+
+/*
+ * Configuration for publishing a track. Publishing is a per-track OPERATION,
+ * not a publisher mode: a track added with moq_pub_add_track may be advertised
+ * (advertise_namespace) and receive SUBSCRIBE, AND/OR be published with
+ * moq_pub_publish_track.
+ */
+typedef struct moq_pub_publish_cfg {
+    uint32_t    struct_size;
+    bool        has_track_alias;
+    uint64_t    track_alias;        /* has_track_alias==false: session assigns */
+    bool        has_forward;
+    bool        forward;            /* initial forward intent (default true) */
+    moq_bytes_t track_properties;   /* opaque track properties (e.g. DYNAMIC_GROUPS) */
+    const moq_auth_token_t *auth_tokens;   /* borrowed for the call */
+    size_t                  auth_token_count;
+} moq_pub_publish_cfg_t;
+
+MOQ_API void moq_pub_publish_cfg_init(moq_pub_publish_cfg_t *cfg);
+
+/*
+ * Send PUBLISH for an existing track (publisher-initiated). The track's
+ * namespace and name from moq_pub_add_track are used.
+ *
+ * Advancing call. Returns MOQ_ERR_REQUEST_BLOCKED if no request capacity and
+ * MOQ_ERR_WOULD_BLOCK if the action queue is full (retry via moq_pub_tick /
+ * moq_pub_flush). Idempotent: a second call while the publication is live
+ * returns MOQ_OK. Returns MOQ_ERR_WRONG_STATE if the track is ended,
+ * MOQ_ERR_CLOSED if the publisher is closed.
+ *
+ * Objects are written with the same moq_pub_write_object[_ex] API -- the
+ * facade routes them to the publication once it is established. Acceptance is
+ * surfaced via moq_pub_track_is_published / on_publish_ok.
+ */
+MOQ_API moq_result_t moq_pub_publish_track(
+    moq_publisher_t *pub,
+    moq_pub_track_t *track,
+    const moq_pub_publish_cfg_t *cfg,
+    uint64_t now_us);
+
+/* Inverse of moq_pub_publish_track: end the publication cleanly (PUBLISH_DONE),
+ * leaving the track and its subscriptions intact. No-op MOQ_OK if never
+ * published. WOULD_BLOCK (retry via tick/flush) / WRONG_STATE (object
+ * mid-stream) / CLOSED. */
+MOQ_API moq_result_t moq_pub_unpublish_track(
+    moq_publisher_t *pub,
+    moq_pub_track_t *track,
+    uint64_t now_us);
+
+/* True once the peer has accepted this track's publication. False for NULL
+ * inputs, a foreign track, a track never published, or while the publication
+ * is still pending / errored / finished. */
+MOQ_API bool moq_pub_track_is_published(
+    const moq_publisher_t *pub,
+    const moq_pub_track_t *track);
+
+/* True when the publication is established AND the peer's forward state is 1. 
+ * Objects written while this is false are still accepted by the facade*/
+MOQ_API bool moq_pub_track_forward(
+    const moq_publisher_t *pub,
+    const moq_pub_track_t *track);
 
 /* -- Retained group (origin-local explicit-FETCH cache) ------------- */
 

--- a/core/include/moq/publisher.h
+++ b/core/include/moq/publisher.h
@@ -234,10 +234,9 @@ MOQ_API moq_result_t moq_pub_publish_track(
     const moq_pub_publish_cfg_t *cfg,
     uint64_t now_us);
 
-/* Inverse of moq_pub_publish_track: end the publication cleanly (PUBLISH_DONE),
- * leaving the track and its subscriptions intact. No-op MOQ_OK if never
- * published. WOULD_BLOCK (retry via tick/flush) / WRONG_STATE (object
- * mid-stream) / CLOSED. */
+/* Inverse of moq_pub_publish_track: end the publication cleanly, leaving the
+ * track and its subscriptions intact. No-op MOQ_OK if never published.
+ * WOULD_BLOCK (retry via tick/flush) / WRONG_STATE (object mid-stream) / CLOSED. */
 MOQ_API moq_result_t moq_pub_unpublish_track(
     moq_publisher_t *pub,
     moq_pub_track_t *track,

--- a/core/src/facade/publisher.c
+++ b/core/src/facade/publisher.c
@@ -24,9 +24,18 @@ typedef struct {
     moq_rcbuf_t *properties;    /* incref'd or NULL */
 } pub_retained_obj_t;
 
+/* A fan-out slot targets EITHER an accepted subscription or a publication we
+ * initiated (kind); the subgroup send path is identical for both. */
+typedef enum {
+    PUB_SLOT_SUBSCRIPTION = 0,
+    PUB_SLOT_PUBLICATION  = 1,
+} pub_slot_kind_t;
+
 typedef struct {
     bool                  active;
-    moq_subscription_t    sub;
+    pub_slot_kind_t       kind;
+    moq_subscription_t    sub;   /* valid when kind == PUB_SLOT_SUBSCRIPTION */
+    moq_publication_t     pub;   /* valid when kind == PUB_SLOT_PUBLICATION  */
     moq_subgroup_handle_t sg;
     bool                  sg_open;
     bool                  sg_has_extensions;
@@ -77,6 +86,13 @@ struct moq_pub_track {
     pub_retained_obj_t *retained;
     size_t              retained_count;
     uint64_t            max_retained_bytes;
+
+    /* Publisher-initiated PUBLISH state, independent of advertise/subscribe
+     * above (both may be live on one track). The data slot opens on PUBLISH_OK. */
+    bool                publish_requested;
+    bool                publish_ok;
+    bool                publish_forward;
+    moq_publication_t   publication;
 };
 
 typedef struct {
@@ -171,7 +187,8 @@ static size_t track_active_count(const moq_pub_track_t *t)
 {
     size_t n = 0;
     for (size_t i = 0; i < t->slot_cap; i++)
-        if (t->slots[i].active) n++;
+        if (t->slots[i].active && t->slots[i].kind == PUB_SLOT_SUBSCRIPTION)
+            n++;
     return n;
 }
 
@@ -185,10 +202,31 @@ static void track_set_subscriber(moq_pub_track_t *t, moq_subscription_t sub)
     pub_sub_slot_t *s = track_find_free_slot(t);
     if (!s) return;
     s->active = true;
+    s->kind = PUB_SLOT_SUBSCRIPTION;
     s->sub = sub;
     s->sg_open = false;
     s->streaming = false;
     s->cur_group = 0;
+}
+
+static void track_set_publication(moq_pub_track_t *t, moq_publication_t pub)
+{
+    pub_sub_slot_t *s = track_find_free_slot(t);
+    if (!s) return;
+    s->active = true;
+    s->kind = PUB_SLOT_PUBLICATION;
+    s->pub = pub;
+    s->sg_open = false;
+    s->streaming = false;
+    s->cur_group = 0;
+}
+
+static pub_sub_slot_t *track_find_publication_slot(moq_pub_track_t *t)
+{
+    for (size_t i = 0; i < t->slot_cap; i++)
+        if (t->slots[i].active && t->slots[i].kind == PUB_SLOT_PUBLICATION)
+            return &t->slots[i];
+    return NULL;
 }
 
 /* Release a retained-object vector (decref each element's refs, free array). */
@@ -375,6 +413,17 @@ static void track_clear_subscriber(moq_pub_track_t *t)
         track_clear_slot(t->pub, &t->slots[i]);
 }
 
+/* True when the caller's callbacks struct is large enough to include the field
+ * at byte offset `off` of width `sz`. */
+static bool cb_has_field(const moq_pub_callbacks_t *cb, size_t off, size_t sz)
+{
+    return cb->struct_size >= off + sz;
+}
+
+#define CB_HAS(cb, field) \
+    (cb_has_field((cb), offsetof(moq_pub_callbacks_t, field), \
+                  sizeof((cb)->field)) && (cb)->field)
+
 /* -- Helpers ------------------------------------------------------ */
 
 static void *pub_alloc(moq_publisher_t *p, size_t sz) {
@@ -520,6 +569,16 @@ static moq_pub_track_t *find_track_by_sub(moq_publisher_t *pub,
 {
     for (moq_pub_track_t *t = pub->tracks; t; t = t->next)
         if (track_find_slot_by_sub(t, sub))
+            return t;
+    return NULL;
+}
+
+static moq_pub_track_t *find_track_by_pub(moq_publisher_t *pub,
+                                           moq_publication_t pub_handle)
+{
+    for (moq_pub_track_t *t = pub->tracks; t; t = t->next)
+        if (t->publish_requested &&
+            moq_publication_eq(t->publication, pub_handle))
             return t;
     return NULL;
 }
@@ -799,7 +858,7 @@ moq_result_t moq_pub_add_track(moq_publisher_t *pub,
     if (!t) return MOQ_ERR_NOMEM;
     memset(t, 0, sizeof(*t));
     t->pub = pub;
-    t->slot_cap = pub->sub_slot_cap;
+    t->slot_cap = pub->sub_slot_cap + 1;
     t->slots = (pub_sub_slot_t *)pub_alloc(pub,
         t->slot_cap * sizeof(pub_sub_slot_t));
     if (!t->slots) {
@@ -922,6 +981,27 @@ moq_result_t moq_pub_remove_track(moq_publisher_t *pub,
         track->ns_entry->refcount <= 1)
         return MOQ_ERR_WRONG_STATE;
 
+    if (track->publish_requested) {
+        pub_sub_slot_t *psl = track_find_publication_slot(track);
+        if (psl && psl->streaming) return MOQ_ERR_WRONG_STATE;
+        if (psl && psl->sg_open) {
+            moq_result_t rc = moq_session_reset_subgroup(pub->session,
+                psl->sg, 0x0, now_us);
+            if (rc == MOQ_ERR_WOULD_BLOCK) return MOQ_ERR_WOULD_BLOCK;
+            if (rc != MOQ_OK && rc != MOQ_ERR_STALE_HANDLE) return rc;
+            psl->sg_open = false;
+        }
+        moq_finish_publish_cfg_t fcfg;
+        moq_finish_publish_cfg_init(&fcfg);
+        moq_result_t rc = moq_session_finish_publish(pub->session,
+            track->publication, &fcfg, now_us);
+        if (rc == MOQ_ERR_WOULD_BLOCK) return MOQ_ERR_WOULD_BLOCK;
+        if (rc != MOQ_OK && rc != MOQ_ERR_STALE_HANDLE) return rc;
+        track->publish_requested = false;
+        track->publish_ok = false;
+        if (psl) track_clear_slot(pub, psl);
+    }
+
     /* Reset the live streaming subgroup on all active slots and retire each
      * publisher-side subscription, so the session frees its subscription entry
      * before the track is dropped. Without the retire step the session keeps the
@@ -934,6 +1014,9 @@ moq_result_t moq_pub_remove_track(moq_publisher_t *pub,
     for (size_t si = 0; si < track->slot_cap; si++) {
         pub_sub_slot_t *sl = &track->slots[si];
         if (!sl->active) continue;
+        /* Publication slots are finished above via PUBLISH_DONE, not retired as
+         * subscriptions; skip them so done_subscribe only sees real subscribers. */
+        if (sl->kind == PUB_SLOT_PUBLICATION) continue;
         if (sl->sg_open) {
             moq_result_t rc = moq_session_reset_subgroup(pub->session,
                 sl->sg, 0x0, now_us);
@@ -1113,8 +1196,12 @@ static moq_result_t write_stream_object(moq_publisher_t *pub,
         sgcfg.object_properties = need_ext;
         sgcfg.end_of_group = want_eog;
 
-        moq_result_t rc = moq_session_open_subgroup(pub->session,
-            slot->sub, &sgcfg, now_us, &slot->sg);
+        moq_result_t rc = (slot->kind == PUB_SLOT_PUBLICATION)
+            ? moq_session_open_pub_subgroup(pub->session,
+                slot->pub, &sgcfg, now_us, &slot->sg)
+            : moq_session_open_subgroup(pub->session,
+                slot->sub, &sgcfg, now_us, &slot->sg);
+
         if (rc == MOQ_ERR_WOULD_BLOCK) return MOQ_ERR_WOULD_BLOCK;
         if (rc == MOQ_ERR_STALE_HANDLE) {
             track_clear_slot(pub, slot);
@@ -1158,9 +1245,13 @@ static moq_result_t write_datagram_object(moq_publisher_t *pub,
     const moq_pub_object_cfg_t *obj, uint64_t now_us)
 {
     if (obj->has_status) {
-        moq_result_t rc = moq_session_send_status_datagram(pub->session,
-            slot->sub, obj->group_id, obj->object_id, track->priority,
-            obj->status, now_us);
+        moq_result_t rc = (slot->kind == PUB_SLOT_PUBLICATION)
+            ? moq_session_send_pub_status_datagram(pub->session,
+                slot->pub, obj->group_id, obj->object_id, track->priority,
+                obj->status, now_us)
+            : moq_session_send_status_datagram(pub->session,
+                slot->sub, obj->group_id, obj->object_id, track->priority,
+                obj->status, now_us);
         if (rc == MOQ_ERR_STALE_HANDLE) {
             track_clear_slot(pub, slot);
             return MOQ_OK;
@@ -1175,9 +1266,13 @@ static moq_result_t write_datagram_object(moq_publisher_t *pub,
         props_len = moq_rcbuf_len(obj->properties);
     }
 
-    moq_result_t rc = moq_session_send_object_datagram(pub->session,
-        slot->sub, obj->group_id, obj->object_id, track->priority,
-        false, obj->payload, props, props_len, now_us);
+    moq_result_t rc = (slot->kind == PUB_SLOT_PUBLICATION)
+        ? moq_session_send_pub_object_datagram(pub->session,
+            slot->pub, obj->group_id, obj->object_id, track->priority,
+            false, obj->payload, props, props_len, now_us)
+        : moq_session_send_object_datagram(pub->session,
+            slot->sub, obj->group_id, obj->object_id, track->priority,
+            false, obj->payload, props, props_len, now_us);
     if (rc == MOQ_ERR_STALE_HANDLE) {
         track_clear_slot(pub, slot);
         return MOQ_OK;
@@ -1251,6 +1346,12 @@ moq_result_t moq_pub_end_track(moq_publisher_t *pub, moq_pub_track_t *track,
     if (track->pub != pub) return MOQ_ERR_INVAL;
     if (pub->closed) return MOQ_ERR_CLOSED;
     if (track->ended) return MOQ_OK;          /* idempotent: already terminated */
+
+    /* End the publication (PUBLISH_DONE) first, then any subscription slot. */
+    {
+        moq_result_t rc = moq_pub_unpublish_track(pub, track, now_us);
+        if (rc != MOQ_OK) return rc;
+    }
 
     /* Single active slot, like the write fan-out (documented v0 limit). */
     pub_sub_slot_t *slot = track_first_active_slot(track);
@@ -1946,6 +2047,99 @@ bool moq_pub_namespace_accepted(const moq_publisher_t *pub,
            track->ns_entry->state == PUB_NS_ACCEPTED;
 }
 
+void moq_pub_publish_cfg_init(moq_pub_publish_cfg_t *cfg)
+{
+    if (!cfg) return;
+    memset(cfg, 0, sizeof(*cfg));
+    cfg->struct_size = sizeof(*cfg);
+    cfg->has_forward = true;
+    cfg->forward = true;
+}
+
+moq_result_t moq_pub_publish_track(moq_publisher_t *pub,
+                                   moq_pub_track_t *track,
+                                   const moq_pub_publish_cfg_t *cfg,
+                                   uint64_t now_us)
+{
+    if (!pub || !track || !cfg) return MOQ_ERR_INVAL;
+    if (track->pub != pub) return MOQ_ERR_INVAL;
+    if (cfg->struct_size < sizeof(moq_pub_publish_cfg_t)) return MOQ_ERR_INVAL;
+    if (pub->closed) return MOQ_ERR_CLOSED;
+    if (track->ended) return MOQ_ERR_WRONG_STATE;
+    if (track->publish_requested) return MOQ_OK;   /* idempotent */
+
+    moq_publish_cfg_t pcfg;
+    moq_publish_cfg_init(&pcfg);
+    pcfg.track_namespace = (moq_namespace_t){ track->ns_parts, track->ns_count };
+    pcfg.track_name = (moq_bytes_t){ track->name_buf, track->name_len };
+    pcfg.has_track_alias = cfg->has_track_alias;
+    pcfg.track_alias = cfg->track_alias;
+    pcfg.has_forward = cfg->has_forward;
+    pcfg.forward = cfg->forward;
+    pcfg.track_properties = cfg->track_properties;
+    pcfg.auth_tokens = cfg->auth_tokens;
+    pcfg.auth_token_count = cfg->auth_token_count;
+
+    moq_publication_t handle;
+    moq_result_t rc = moq_session_publish(pub->session, &pcfg, now_us, &handle);
+    if (rc < 0) return rc;   /* REQUEST_BLOCKED / WOULD_BLOCK: nothing bound, retry */
+
+    track->publication = handle;
+    track->publish_requested = true;
+    track->publish_forward = cfg->has_forward ? cfg->forward : true;
+    return MOQ_OK;
+}
+
+moq_result_t moq_pub_unpublish_track(moq_publisher_t *pub,
+                                     moq_pub_track_t *track,
+                                     uint64_t now_us)
+{
+    if (!pub || !track) return MOQ_ERR_INVAL;
+    if (track->pub != pub) return MOQ_ERR_INVAL;
+    if (pub->closed) return MOQ_ERR_CLOSED;
+    if (!track->publish_requested) return MOQ_OK;   /* not published: no-op */
+
+    /* Close the data subgroup cleanly before PUBLISH_DONE (finish needs no open
+     * stream). Retryable: WOULD_BLOCK at any step lets the caller retry. */
+    pub_sub_slot_t *psl = track_find_publication_slot(track);
+    if (psl && psl->streaming) return MOQ_ERR_WRONG_STATE;
+    if (psl && psl->sg_open) {
+        moq_result_t rc = moq_session_close_subgroup(pub->session,
+            psl->sg, now_us);
+        if (rc == MOQ_ERR_WOULD_BLOCK) return MOQ_ERR_WOULD_BLOCK;
+        if (rc != MOQ_OK && rc != MOQ_ERR_STALE_HANDLE) return rc;
+        psl->sg_open = false;
+    }
+
+    moq_finish_publish_cfg_t fcfg;
+    moq_finish_publish_cfg_init(&fcfg);
+    moq_result_t rc = moq_session_finish_publish(pub->session,
+        track->publication, &fcfg, now_us);
+    if (rc == MOQ_ERR_WOULD_BLOCK) return MOQ_ERR_WOULD_BLOCK;
+    if (rc != MOQ_OK && rc != MOQ_ERR_STALE_HANDLE) return rc;
+
+    track->publish_requested = false;
+    track->publish_ok = false;
+    if (psl) track_clear_slot(pub, psl);
+    return MOQ_OK;
+}
+
+bool moq_pub_track_is_published(const moq_publisher_t *pub,
+                                const moq_pub_track_t *track)
+{
+    if (!pub || !track) return false;
+    if (track->pub != pub) return false;
+    return track->publish_ok;
+}
+
+bool moq_pub_track_forward(const moq_publisher_t *pub,
+                           const moq_pub_track_t *track)
+{
+    if (!pub || !track) return false;
+    if (track->pub != pub) return false;
+    return track->publish_ok && track->publish_forward;
+}
+
 bool moq_pub_is_draining(const moq_publisher_t *pub)
 {
     if (!pub) return false;
@@ -2106,6 +2300,66 @@ moq_result_t moq_pub_tick(moq_publisher_t *pub, uint64_t now_us)
                     ev.u.subscribe_updated.delivery_timeout_us;
                 pub->callbacks.on_subscriber_updated(
                     pub->callbacks.ctx, t, &info);
+            }
+            break;
+        }
+
+        case MOQ_EVENT_PUBLISH_OK: {
+            moq_pub_track_t *t = find_track_by_pub(pub,
+                ev.u.publish_ok.pub);
+            if (t) {
+                t->publish_ok = true;
+                t->publish_forward = ev.u.publish_ok.send_allowed;
+                if (!track_find_publication_slot(t))
+                    track_set_publication(t, t->publication);
+                if (CB_HAS(&pub->callbacks, on_publish_ok))
+                    pub->callbacks.on_publish_ok(pub->callbacks.ctx, t,
+                        t->publish_forward);
+            }
+            break;
+        }
+
+        case MOQ_EVENT_PUBLISH_UPDATED: {
+            moq_pub_track_t *t = find_track_by_pub(pub,
+                ev.u.publish_updated.pub);
+            if (t && ev.u.publish_updated.has_forward) {
+                t->publish_forward = ev.u.publish_updated.forward;
+                if (CB_HAS(&pub->callbacks, on_publish_forward_changed))
+                    pub->callbacks.on_publish_forward_changed(
+                        pub->callbacks.ctx, t, t->publish_forward);
+            }
+            break;
+        }
+
+        case MOQ_EVENT_PUBLISH_ERROR: {
+            moq_pub_track_t *t = find_track_by_pub(pub,
+                ev.u.publish_error.pub);
+            if (t) {
+                /* Publication terminated before acceptance: clear so a later
+                 * moq_pub_publish_track may retry, and drop any data slot. */
+                t->publish_requested = false;
+                t->publish_ok = false;
+                pub_sub_slot_t *sl = track_find_publication_slot(t);
+                if (sl) track_clear_slot(pub, sl);
+                if (CB_HAS(&pub->callbacks, on_publish_error))
+                    pub->callbacks.on_publish_error(pub->callbacks.ctx, t,
+                        ev.u.publish_error.error_code);
+            }
+            break;
+        }
+
+        case MOQ_EVENT_PUBLISH_FINISHED:
+        case MOQ_EVENT_PUBLISH_UNSUBSCRIBED: {
+            moq_publication_t ph = (ev.kind == MOQ_EVENT_PUBLISH_FINISHED)
+                ? ev.u.publish_finished.pub
+                : ev.u.publish_unsubscribed.pub;
+            moq_pub_track_t *t = find_track_by_pub(pub, ph);
+            if (t) {
+                t->publish_ok = false;
+                pub_sub_slot_t *sl = track_find_publication_slot(t);
+                if (sl) track_clear_slot(pub, sl);
+                if (CB_HAS(&pub->callbacks, on_publish_finished))
+                    pub->callbacks.on_publish_finished(pub->callbacks.ctx, t);
             }
             break;
         }

--- a/examples/service/media_publish_loc.c
+++ b/examples/service/media_publish_loc.c
@@ -1,0 +1,412 @@
+/*
+ * media_publish_loc — publish a real H.264 elementary stream over moq::service
+ * using RAW/LOC packaging. POC companion to media_send.c.
+ *
+ * Unlike media_send.c (placeholder payloads), this reads an H.264 Annex-B
+ * byte-stream from stdin (e.g. piped from ffmpeg), splits it into access units,
+ * derives the decoder config (avcC) from the first SPS/PPS, advertises a video
+ * track, and writes each access unit as a RAW/LOC media object. The service
+ * generates the LOC-01 properties (Capture Timestamp from presentation_time_us,
+ * Video Frame Marking independent=is_sync) that a LOC player (e.g. moq-playa)
+ * consumes via WebCodecs.
+ *
+ * The stdin stream MUST carry an Access Unit Delimiter (NAL type 9) at the start
+ * of every access unit so AUs can be split cheaply; ffmpeg inserts these with
+ *   -bsf:v h264_metadata=aud=insert
+ *
+ * Usage: media_publish_loc <url> <namespace> [track]
+ *   url        moqt://host:port[/path]  (raw QUIC), or https://host:port/path (WT)
+ *   namespace  slash-separated, e.g. "demo"
+ *   track      track name (default "video")
+ *
+ * Example:
+ *   ffmpeg -re -stream_loop -1 -f lavfi -i testsrc=size=1280x720:rate=30 \
+ *     -c:v libx264 -profile:v baseline -pix_fmt yuv420p -g 30 -keyint_min 30 \
+ *     -x264-params scenecut=0 -bsf:v h264_metadata=aud=insert -f h264 pipe:1 \
+ *   | ./moq_example_media_publish_loc moqt://localhost:4433/moq-relay demo video
+ */
+#include <moq/endpoint.h>
+#include <moq/media_sender.h>
+#include <moq/rcbuf.h>
+
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Video geometry advertised in the catalog. Match these to the ffmpeg source
+ * (testsrc=size=WxH:rate=FPS). Width/height are informational hints; the player
+ * also derives geometry from the in-band SPS. */
+#define VIDEO_WIDTH    1280
+#define VIDEO_HEIGHT   720
+#define VIDEO_FPS      30
+#define VIDEO_BITRATE  2000000ull
+#define FRAME_DUR_US   (1000000ull / VIDEO_FPS)
+
+static volatile sig_atomic_t g_stop = 0;
+static void on_signal(int sig) { (void)sig; g_stop = 1; }
+
+static size_t split_namespace(char *buf, moq_bytes_t *parts, size_t max)
+{
+    size_t n = 0;
+    char *p = buf;
+    while (*p && n < max) {
+        char *slash = strchr(p, '/');
+        if (slash)
+            *slash = '\0';
+        parts[n].data = (const uint8_t *)p;
+        parts[n].len = strlen(p);
+        n++;
+        if (!slash)
+            break;
+        p = slash + 1;
+    }
+    return n;
+}
+
+/* -- H.264 Annex-B helpers ------------------------------------------------- */
+
+/* Is there a 3- or 4-byte start code at b[i]? Sets *scl to its length. */
+static int is_start_code(const uint8_t *b, size_t len, size_t i, int *scl)
+{
+    if (i + 4 <= len && b[i] == 0 && b[i + 1] == 0 && b[i + 2] == 0 &&
+        b[i + 3] == 1) { *scl = 4; return 1; }
+    if (i + 3 <= len && b[i] == 0 && b[i + 1] == 0 && b[i + 2] == 1) {
+        *scl = 3; return 1; }
+    return 0;
+}
+
+/* Index of the next start code (at/after `from`) whose NAL type is `want`,
+ * or -1 if none is found within the buffer. */
+static long find_nal(const uint8_t *b, size_t len, size_t from, int want)
+{
+    for (size_t i = from; i + 4 < len; i++) {
+        int scl;
+        if (is_start_code(b, len, i, &scl)) {
+            size_t h = i + scl;
+            if (h < len && (b[h] & 0x1F) == want)
+                return (long)i;
+            i += scl - 1;   /* skip the start code we just matched */
+        }
+    }
+    return -1;
+}
+
+/* Captured parameter sets (NAL bytes incl. header, no start code). */
+static uint8_t g_sps[256]; static size_t g_sps_len = 0;
+static uint8_t g_pps[256]; static size_t g_pps_len = 0;
+static bool    g_have_params = false;
+
+/* Walk the NALs of one access unit: set *has_idr if it contains an IDR slice
+ * (NAL type 5), and capture the first SPS (7) and PPS (8) we ever see. */
+static void scan_au(const uint8_t *b, size_t len, int *has_idr)
+{
+    size_t i = 0;
+    while (i < len) {
+        int scl;
+        if (!is_start_code(b, len, i, &scl)) { i++; continue; }
+        size_t h = i + scl;
+        if (h >= len) break;
+        int type = b[h] & 0x1F;
+
+        /* End of this NAL = next start code, or end of AU. */
+        size_t nal_end = len;
+        for (size_t j = h + 1; j + 3 <= len; j++) {
+            int s2;
+            if (is_start_code(b, len, j, &s2)) { nal_end = j; break; }
+        }
+        size_t nal_len = nal_end - h;   /* bytes incl. NAL header */
+
+        if (type == 5) *has_idr = 1;
+        if (type == 7 && g_sps_len == 0 && nal_len <= sizeof(g_sps)) {
+            memcpy(g_sps, b + h, nal_len); g_sps_len = nal_len;
+        }
+        if (type == 8 && g_pps_len == 0 && nal_len <= sizeof(g_pps)) {
+            memcpy(g_pps, b + h, nal_len); g_pps_len = nal_len;
+        }
+        i = nal_end;
+    }
+    if (g_sps_len >= 4 && g_pps_len > 0) g_have_params = true;
+}
+
+/* Build a minimal AVCDecoderConfigurationRecord (avcC) from SPS+PPS. */
+static size_t build_avcc(uint8_t *out, size_t cap)
+{
+    size_t need = 8 + g_sps_len + 3 + g_pps_len;
+    if (g_sps_len < 4 || need > cap) return 0;
+    size_t p = 0;
+    out[p++] = 0x01;            /* configurationVersion */
+    out[p++] = g_sps[1];        /* AVCProfileIndication */
+    out[p++] = g_sps[2];        /* profile_compatibility */
+    out[p++] = g_sps[3];        /* AVCLevelIndication */
+    out[p++] = 0xFF;            /* 6 bits reserved + lengthSizeMinusOne (=3) */
+    out[p++] = 0xE1;            /* 3 bits reserved + numOfSPS (=1) */
+    out[p++] = (uint8_t)(g_sps_len >> 8);
+    out[p++] = (uint8_t)(g_sps_len & 0xFF);
+    memcpy(out + p, g_sps, g_sps_len); p += g_sps_len;
+    out[p++] = 0x01;            /* numOfPPS */
+    out[p++] = (uint8_t)(g_pps_len >> 8);
+    out[p++] = (uint8_t)(g_pps_len & 0xFF);
+    memcpy(out + p, g_pps, g_pps_len); p += g_pps_len;
+    return p;
+}
+
+/* -- Publish state --------------------------------------------------------- */
+
+typedef struct {
+    moq_media_sender_t *tx;
+    moq_media_track_t  *trk;
+    bool                track_added;
+    uint64_t            frame_idx;
+    unsigned long long  sent;
+    unsigned long long  dropped;
+} pub_state_t;
+
+/* Add the video track once SPS/PPS are known (avcC -> init_data). */
+static int ensure_track(pub_state_t *st, const char *track)
+{
+    if (st->track_added) return 0;
+    if (!g_have_params) return 0;
+
+    uint8_t avcc[600];
+    size_t avcc_len = build_avcc(avcc, sizeof(avcc));
+    if (avcc_len == 0) {
+        fprintf(stderr, "failed to build avcC\n");
+        return -1;
+    }
+    char codec[32];
+    snprintf(codec, sizeof(codec), "avc1.%02x%02x%02x",
+             g_sps[1], g_sps[2], g_sps[3]);
+
+    moq_media_track_cfg_t tc;
+    moq_media_track_cfg_init(&tc);
+    tc.name.data = (const uint8_t *)track;
+    tc.name.len = strlen(track);
+    tc.media_type = MOQ_MEDIA_TYPE_VIDEO;
+    tc.packaging = MOQ_MEDIA_PACKAGING_RAW;   /* RAW/LOC: service makes LOC */
+    tc.codec.data = (const uint8_t *)codec;
+    tc.codec.len = strlen(codec);
+    tc.init_data.data = avcc;                  /* copied during add_track */
+    tc.init_data.len = avcc_len;
+    tc.width = VIDEO_WIDTH;
+    tc.height = VIDEO_HEIGHT;
+    tc.framerate_millis = (uint64_t)VIDEO_FPS * 1000;
+    tc.bitrate = VIDEO_BITRATE;
+    tc.is_live = true;
+
+    moq_result_t rc = moq_media_sender_add_track(st->tx, &tc, &st->trk);
+    if (rc != MOQ_OK) {
+        fprintf(stderr, "add_track failed: %d\n", (int)rc);
+        return -1;
+    }
+    st->track_added = true;
+    fprintf(stderr, "track added: name=%s codec=%s avcC=%zuB (sps=%zu pps=%zu)\n",
+            track, codec, avcc_len, g_sps_len, g_pps_len);
+    return 0;
+}
+
+/* Emit one access unit (Annex-B bytes) as a RAW object.
+ * The browser uses WebCodecs in Annex-B mode (no description). */
+static int emit_au(pub_state_t *st, const char *track,
+                   const uint8_t *au, size_t au_len)
+{
+    int has_idr = 0;
+    scan_au(au, au_len, &has_idr);
+
+    if (ensure_track(st, track) != 0) return -1;
+    if (!st->track_added) return 0;
+
+    moq_rcbuf_t *payload = NULL;
+    if (moq_rcbuf_create(moq_alloc_default(), au, au_len, &payload) != MOQ_OK)
+        return -1;
+
+    moq_media_send_object_t o;
+    memset(&o, 0, sizeof(o));
+    o.struct_size = sizeof(o);
+    o.payload = payload;
+    o.is_sync = has_idr ? true : false;
+    o.starts_group = o.is_sync;       /* keyframe opens a new group (GOP) */
+    o.presentation_time_us = st->frame_idx * FRAME_DUR_US;
+    o.decode_time_us = o.presentation_time_us;
+
+    moq_result_t wr = moq_media_sender_write(st->tx, st->trk, &o);
+    if (wr == MOQ_OK) {
+        st->sent++;
+        st->frame_idx++;
+    } else if (wr == MOQ_ERR_WOULD_BLOCK) {
+        moq_rcbuf_decref(payload);    /* dropped by the live policy */
+        st->dropped++;
+        st->frame_idx++;
+    } else if (wr == MOQ_ERR_INTERRUPTED || wr == MOQ_ERR_CLOSED) {
+        moq_rcbuf_decref(payload);
+        return -1;
+    } else {
+        moq_rcbuf_decref(payload);
+        fprintf(stderr, "write failed: %d\n", (int)wr);
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <url> <namespace> [track]\n", argv[0]);
+        return 2;
+    }
+    const char *url = argv[1];
+    char nsbuf[256];
+    snprintf(nsbuf, sizeof(nsbuf), "%s", argv[2]);
+    moq_bytes_t ns_parts[32];
+    size_t ns_count = split_namespace(nsbuf, ns_parts, 32);
+    const char *track = (argc > 3) ? argv[3] : "video";
+
+    signal(SIGINT, on_signal);
+
+    /* 1. Pre-read stdin until we have SPS+PPS (first IDR AU). This ensures
+     *    the track config (avcC) is known BEFORE we connect to the relay, so
+     *    the initial catalog published after ANNOUNCE_OK already contains the
+     *    video track — avoiding an empty first-catalog race. */
+    uint8_t *pb = NULL;
+    size_t pb_len = 0, pb_cap = 0;
+    uint8_t chunk[65536];
+
+    fprintf(stderr, "pre-reading stdin for SPS/PPS...\n");
+    while (!g_stop && !g_have_params) {
+        size_t got = fread(chunk, 1, sizeof(chunk), stdin);
+        if (got == 0) { if (feof(stdin) || ferror(stdin)) break; continue; }
+        if (pb_len + got > pb_cap) {
+            size_t ncap = (pb_len + got) * 2 + 131072;
+            uint8_t *np = (uint8_t *)realloc(pb, ncap);
+            if (!np) { free(pb); fprintf(stderr, "oom\n"); return 1; }
+            pb = np; pb_cap = ncap;
+        }
+        memcpy(pb + pb_len, chunk, got);
+        pb_len += got;
+        /* Scan all complete AUs so far to extract SPS/PPS. */
+        size_t scan = 0;
+        long a;
+        while ((a = find_nal(pb, pb_len, scan, 9)) >= 0) {
+            long b = find_nal(pb, pb_len, (size_t)a + 4, 9);
+            if (b < 0) break;
+            int dummy = 0; scan_au(pb + a, (size_t)(b - a), &dummy);
+            scan = (size_t)b;
+        }
+    }
+    if (!g_have_params) {
+        free(pb);
+        fprintf(stderr, "failed to get SPS/PPS from stdin\n");
+        return 1;
+    }
+    fprintf(stderr, "SPS/PPS found, connecting to relay...\n");
+
+    /* 2. Open the endpoint (raw QUIC for moqt://, WebTransport for https://). */
+    moq_endpoint_cfg_t ec;
+    moq_endpoint_cfg_init(&ec);
+    ec.url.data = (const uint8_t *)url;
+    ec.url.len = strlen(url);
+    ec.insecure_skip_verify = true;   /* demo only */
+
+    moq_endpoint_t *ep = NULL;
+    moq_result_t rc = moq_endpoint_connect(&ec, &ep);
+    if (rc != MOQ_OK) {
+        free(pb); fprintf(stderr, "endpoint connect failed: %d\n", (int)rc);
+        return 1;
+    }
+
+    /* 3. Attach a sender (live preset: DROP_TO_KEYFRAME). */
+    moq_media_sender_cfg_t scfg;
+    moq_media_sender_cfg_init_live(&scfg);
+    scfg.endpoint = NULL;                 /* attach mode: we own ep above */
+    scfg.namespace_.parts = ns_parts;
+    scfg.namespace_.count = ns_count;
+
+    moq_media_sender_t *tx = NULL;
+    rc = moq_media_sender_attach(ep, &scfg, &tx);
+    if (rc != MOQ_OK) {
+        free(pb); fprintf(stderr, "sender attach failed: %d\n", (int)rc);
+        moq_endpoint_stop(ep);
+        moq_endpoint_destroy(ep);
+        return 1;
+    }
+
+    pub_state_t st;
+    memset(&st, 0, sizeof(st));
+    st.tx = tx;
+
+    /* Add the track immediately — before the network thread has a chance to
+     * process ANNOUNCE_OK and publish the initial catalog. g_have_params is
+     * already true from the pre-read phase. */
+    if (ensure_track(&st, track) != 0) {
+        free(pb);
+        moq_media_sender_destroy(tx);
+        moq_endpoint_stop(ep);
+        moq_endpoint_destroy(ep);
+        return 1;
+    }
+
+    /* 4. Read Annex-B from stdin (pb already holds the pre-read bytes from
+     *    phase 1). Continue splitting on AUDs and emitting. */
+    bool eof = false;
+
+    while (!g_stop && !eof) {
+        uint8_t chunk2[65536];
+        size_t got = fread(chunk2, 1, sizeof(chunk2), stdin);
+        if (got == 0) {
+            if (feof(stdin)) eof = true;
+            else if (ferror(stdin)) break;
+        }
+        if (got > 0) {
+            if (pb_len + got > pb_cap) {
+                size_t ncap = (pb_len + got) * 2;
+                uint8_t *np = (uint8_t *)realloc(pb, ncap);
+                if (!np) { fprintf(stderr, "oom\n"); break; }
+                pb = np; pb_cap = ncap;
+            }
+            memcpy(pb + pb_len, chunk2, got);
+            pb_len += got;
+        }
+
+        /* Find the first AU start (AUD). */
+        long au_start = find_nal(pb, pb_len, 0, 9);
+        if (au_start < 0) {
+            if (eof) break;
+            continue;   /* need more bytes */
+        }
+
+        /* Emit each complete AU [au_start, next_aud). */
+        size_t search = (size_t)au_start + 4;
+        long next;
+        while ((next = find_nal(pb, pb_len, search, 9)) >= 0) {
+            if (emit_au(&st, track, pb + au_start, (size_t)(next - au_start)) != 0) {
+                g_stop = 1; break;
+            }
+            au_start = next;
+            search = (size_t)au_start + 4;
+        }
+
+        if (eof && !g_stop) {
+            emit_au(&st, track, pb + au_start, pb_len - (size_t)au_start);
+            pb_len = 0;
+        } else if (au_start > 0) {
+            /* Keep the in-progress AU; drop everything before it. */
+            memmove(pb, pb + au_start, pb_len - (size_t)au_start);
+            pb_len -= (size_t)au_start;
+        }
+    }
+
+    free(pb);
+
+    if (st.track_added)
+        moq_media_sender_end_track(tx, st.trk);
+
+    fprintf(stderr, "done: sent=%llu dropped=%llu\n", st.sent, st.dropped);
+
+    /* 4. Teardown: child first, then the endpoint. */
+    moq_media_sender_destroy(tx);
+    moq_endpoint_stop(ep);
+    moq_endpoint_destroy(ep);
+    return 0;
+}

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -331,6 +331,18 @@ if(MOQ_BUILD_TESTS)
         target_include_directories(test_media_sender_catalog PRIVATE
             ${CMAKE_SOURCE_DIR}/tests/unit)
         add_test(NAME media_sender_catalog COMMAND test_media_sender_catalog)
+
+        # Lifecycle callbacks (on_ready / on_closed): deterministic, no network.
+        # Drives the production fire helpers via the same test seam.
+        add_executable(test_media_sender_lifecycle
+            tests/test_media_sender_lifecycle.c)
+        target_link_libraries(test_media_sender_lifecycle PRIVATE
+            moq-service-sender-test-internals moq::core moq::msf
+            Threads::Threads)
+        target_include_directories(test_media_sender_lifecycle PRIVATE
+            ${CMAKE_SOURCE_DIR}/tests/unit)
+        add_test(NAME media_sender_lifecycle
+            COMMAND test_media_sender_lifecycle)
     endif()
 
     # Lifecycle tests need a real network loopback: a threaded-picoquic

--- a/service/include/moq/media_sender.h
+++ b/service/include/moq/media_sender.h
@@ -84,6 +84,11 @@ typedef struct moq_media_sender_callbacks {
     void (*on_subscriber_left)(
         void *ctx, moq_media_sender_t *sender, moq_media_track_t *track,
         size_t active_subscriptions);
+    void (*on_ready)(void *ctx, moq_media_sender_t *sender);
+    void (*on_closed)(void *ctx, moq_media_sender_t *sender,
+                      bool is_fatal, uint64_t fatal_code);
+    void (*on_track_closed)(void *ctx, moq_media_sender_t *sender,
+                            moq_media_track_t *track);
 } moq_media_sender_callbacks_t;
 
 MOQ_API void moq_media_sender_callbacks_init(moq_media_sender_callbacks_t *cb);
@@ -152,6 +157,11 @@ typedef struct moq_media_sender_cfg {
      * create/attach; ctx and the function pointers are retained for the
      * sender's life. Leave zeroed for no callbacks (queries still work). */
     moq_media_sender_callbacks_t         callbacks;
+
+    /* false: advertise + answer SUBSCRIBE (pull).
+     * true: also PUBLISH every track and emit the catalog live so a relay
+     * caches it without a FETCH (push). Default to false. */
+    bool                                 publish_tracks;
 } moq_media_sender_cfg_t;
 
 /* Plain init leaves backpressure UNSET on purpose -- the choice is forced,

--- a/service/include/moq/media_sender.h
+++ b/service/include/moq/media_sender.h
@@ -162,6 +162,10 @@ typedef struct moq_media_sender_cfg {
      * true: also PUBLISH every track and emit the catalog live so a relay
      * caches it without a FETCH (push). Default to false. */
     bool                                 publish_tracks;
+
+    /* Media written while its track has no demand: false (default) holds it
+     * queued until demand appears; true drops it to stay at the live edge. */
+    bool                                 drop_without_demand;
 } moq_media_sender_cfg_t;
 
 /* Plain init leaves backpressure UNSET on purpose -- the choice is forced,

--- a/service/src/endpoint.c
+++ b/service/src/endpoint.c
@@ -1065,6 +1065,18 @@ bool moq_endpoint_is_closed_internal(const moq_endpoint_t *ep)
     return ep_terminal(ep);
 }
 
+bool moq_endpoint_is_fatal_internal(const moq_endpoint_t *ep)
+{
+    if (!ep) return false;
+    return ep_facade_is_fatal(ep);
+}
+
+uint64_t moq_endpoint_fatal_code_internal(const moq_endpoint_t *ep)
+{
+    if (!ep) return 0;
+    return ep_facade_fatal_code(ep);
+}
+
 void moq_endpoint_detach_hook(moq_endpoint_t *ep,
                               moq_endpoint_hook_kind_t kind, void *ctx)
 {

--- a/service/src/endpoint_internal.h
+++ b/service/src/endpoint_internal.h
@@ -93,6 +93,9 @@ bool moq_endpoint_interrupted_internal(const moq_endpoint_t *ep);
  * take its own non-endpoint lock). Safe to call from any thread. */
 bool moq_endpoint_is_closed_internal(const moq_endpoint_t *ep);
 
+bool moq_endpoint_is_fatal_internal(const moq_endpoint_t *ep);
+uint64_t moq_endpoint_fatal_code_internal(const moq_endpoint_t *ep);
+
 /* Internal retryable post: like moq_endpoint_post(), but a task that returns
  * MOQ_ERR_WOULD_BLOCK is REQUEUED (the same node, no re-allocation) to run again
  * on a later pump cycle instead of being freed -- allocation-free retry for work

--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -262,6 +262,8 @@ struct moq_media_sender {
                                              strict by default (cfg_init) */
     bool             publish_tracks;      /* publisher-initiated PUBLISH per
                                              track + live initial catalog */
+    bool             drop_without_demand; /* drop queued media without demand
+                                             (live edge); default: hold */
     uint64_t         block_timeout_us;
     uint32_t         preq_cap;            /* pre-ready object bound */
     uint64_t         preq_byte_cap;
@@ -1312,10 +1314,11 @@ static void sender_drain(moq_media_sender_t *s, uint64_t now_us)
             continue;
         }
 
-        /* No demand: the facade would no-op the write, so drop the queued media
-         * outright to stay at the live edge (head still blocks behind it, v0). */
+        /* No demand: drop_without_demand drops the queued media to stay at
+         * the live edge; the default holds the head until demand appears. */
         if (!has_sub) {
-            preq_drop_all_for_track(s, t);
+            if (s->drop_without_demand)
+                preq_drop_all_for_track(s, t);
             break;
         }
 
@@ -2774,6 +2777,10 @@ static moq_result_t sender_new(moq_endpoint_t *ep, bool owns,
     if (cfg->struct_size >= offsetof(moq_media_sender_cfg_t, publish_tracks) +
                                 sizeof(cfg->publish_tracks))
         s->publish_tracks = cfg->publish_tracks;
+    if (cfg->struct_size >= offsetof(moq_media_sender_cfg_t,
+                                     drop_without_demand) +
+                                sizeof(cfg->drop_without_demand))
+        s->drop_without_demand = cfg->drop_without_demand;
     s->block_timeout_us = cfg->block_timeout_us
         ? cfg->block_timeout_us : SENDER_DEFAULT_BLOCK_TIMEOUT_US;
     s->queue_cap = cfg->queue_max_objects

--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -1927,6 +1927,11 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
         sender_fire_closed(s, true, fatal_code);
         return;
     }
+
+    if (sender_ep_closed(s)) {
+        sender_fire_closed(s, moq_endpoint_is_fatal_internal(s->ep),
+                           moq_endpoint_fatal_code_internal(s->ep));
+    }
     if (!session) return;
 
     if (!s->pub) {

--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -114,6 +114,8 @@ struct moq_media_track {
                                                 from moq_pub_active_subscriptions()
                                                 for demand visibility (§7.2) */
     bool                  is_catalog;        /* the catalog track */
+    bool                  pub_closed_fired;  /* on_track_closed fired: latched so a
+                                                repeated PUBLISH_FINISHED does not re-fire */
     bool                  removed;           /* remove_track called: excluded from
                                                 future catalog builds, writes
                                                 refused; handle kept until destroy */
@@ -258,6 +260,8 @@ struct moq_media_sender {
     moq_media_send_backpressure_t backpressure;
     bool             validate_cmaf;       /* CMSF §3.3/§3.4 object validation;
                                              strict by default (cfg_init) */
+    bool             publish_tracks;      /* publisher-initiated PUBLISH per
+                                             track + live initial catalog */
     uint64_t         block_timeout_us;
     uint32_t         preq_cap;            /* pre-ready object bound */
     uint64_t         preq_byte_cap;
@@ -281,6 +285,10 @@ struct moq_media_sender {
     bool              fatal;
     uint64_t          fatal_code;
 
+    /* Latches so on_ready / on_closed each fire at most once (network thread). */
+    bool              ready_fired;
+    bool              closed_fired;
+
     moq_media_sender_stats_t stats;       /* counters (mu-protected) */
 
     /* Catalog republish (S1). catalog_dirty is set by add_track/remove_track
@@ -298,6 +306,7 @@ struct moq_media_sender {
     moq_publisher_t  *pub;
     moq_media_track_t *catalog_track;
     bool              catalog_published;     /* initial retained catalog installed */
+    bool              live_catalog_sent;     /* initial catalog emitted live (publish) */
     uint64_t          catalog_group;        /* last published generation (0 = initial) */
     moq_rcbuf_t      *published_catalog;     /* last committed catalog bytes (the
                                                 independent base / no-op dedup) */
@@ -327,11 +336,43 @@ static void sender_set_fatal_locked(moq_media_sender_t *s, uint64_t code)
     pthread_cond_broadcast(&s->space_cv);   /* unblock BLOCK_TIMEOUT waiters */
 }
 
+/* Fire on_closed at most once. Claims closed_fired under the lock, then invokes
+ * the callback OUTSIDE it (non-reentrant contract). Network thread. */
+static void sender_fire_closed(moq_media_sender_t *s, bool is_fatal,
+                               uint64_t fatal_code)
+{
+    pthread_mutex_lock(&s->mu);
+    if (s->closed_fired) { pthread_mutex_unlock(&s->mu); return; }
+    s->closed_fired = true;
+    void *cbctx = s->callbacks.ctx;
+    void (*cb)(void *, moq_media_sender_t *, bool, uint64_t)
+        = s->callbacks.on_closed;
+    pthread_mutex_unlock(&s->mu);
+
+    if (cb) cb(cbctx, s, is_fatal, fatal_code);
+}
+
+/* Fire on_ready at most once, on the network thread, OUTSIDE s->mu. Claims the
+ * ready_fired latch under the lock, then invokes the callback after release. */
+static void sender_fire_ready(moq_media_sender_t *s)
+{
+    pthread_mutex_lock(&s->mu);
+    if (s->ready_fired) { pthread_mutex_unlock(&s->mu); return; }
+    s->ready_fired = true;
+    void *cbctx = s->callbacks.ctx;
+    void (*cb)(void *, moq_media_sender_t *) = s->callbacks.on_ready;
+    pthread_mutex_unlock(&s->mu);
+
+    if (cb) cb(cbctx, s);
+}
+
 static void sender_set_fatal(moq_media_sender_t *s, uint64_t code)
 {
     pthread_mutex_lock(&s->mu);
     sender_set_fatal_locked(s, code);
     pthread_mutex_unlock(&s->mu);
+    /* A fatal is a terminal close: surface it as on_closed(is_fatal=true). */
+    sender_fire_closed(s, true, code);
 }
 
 static bool sender_terminal(const moq_media_sender_t *s)
@@ -461,6 +502,40 @@ static bool preq_track_anchor(const moq_media_sender_t *s,
         }
     }
     return found;
+}
+
+/* Drop all queued media of `track` while it has no demand, keeping the sender at
+ * the live edge (the peer accepts a mid-GOP resume gap for minimal latency).
+ * Preserves the terminal END_OF_TRACK (is_end) and arms pending_reset if a wire
+ * subgroup is open. Single compaction pass. mu held. */
+static void preq_drop_all_for_track(moq_media_sender_t *s,
+                                    moq_media_track_t *t)
+{
+    uint32_t rd = s->preq_head, wr = s->preq_head;
+    bool dropped_any = false;
+    while (rd != s->preq_tail) {
+        sender_preq_entry_t *e = &s->preq[rd % s->ring_cap];
+        if (e->track == t && !e->is_end) {
+            s->preq_bytes -= e->bytes;
+            s->stats.objects_dropped++;
+            if (e->is_sync) s->stats.keyframes_dropped++;
+            preq_entry_release(s, e);   /* clears the slot */
+            dropped_any = true;
+        } else {
+            if (wr != rd) s->preq[wr % s->ring_cap] = *e;
+            wr++;
+        }
+        rd++;
+    }
+    s->preq_tail = wr;
+    if (dropped_any) {
+        s->stats.groups_dropped++;
+        /* An open wire subgroup for this track just lost its tail - the drain
+         * must RESET it, not leave it truncated. */
+        if (t->emit_open)
+            t->pending_reset = true;
+        pthread_cond_broadcast(&s->space_cv);   /* freed space: wake writers */
+    }
 }
 
 /* Evict the oldest group that can go without stranding any track's
@@ -966,6 +1041,17 @@ static void sap_history_append(moq_media_sender_t *s, moq_media_track_t *tl,
     if (tl->sap_lead < tl->sap_base_seq) tl->sap_lead = tl->sap_base_seq;
 }
 
+/* Whether a track wants data on the wire: a subscriber (pull), or the
+ * publication established with forward on (publish-initiated). */
+static bool sender_track_demand(moq_media_sender_t *s, moq_media_track_t *t)
+{
+    if (!t || !t->pub_track) return false;
+    if (moq_pub_has_subscriber(s->pub, t->pub_track)) return true;
+    if (s->publish_tracks)
+        return moq_pub_track_forward(s->pub, t->pub_track);
+    return false;
+}
+
 /* Emit timeline objects for `tl` from its side history, gated on the timeline
  * track's OWN subscriber so it can never head-of-line-block media (MSF §8.3).
  * The timeline shares the media group ids: each new media group boundary emits
@@ -978,7 +1064,7 @@ static void sender_emit_sap_for(moq_media_sender_t *s, moq_media_track_t *tl,
                                 uint64_t now_us)
 {
     if (!tl->pub_track) return;
-    if (!moq_pub_has_subscriber(s->pub, tl->pub_track)) return;
+    if (!sender_track_demand(s, tl)) return;
 
     uint64_t next_seq = tl->sap_base_seq + tl->sap_rec_count;
     while (tl->sap_lead < next_seq) {
@@ -1097,7 +1183,7 @@ static void sender_emit_mt_for(moq_media_sender_t *s, moq_media_track_t *tl,
                                uint64_t now_us)
 {
     if (!tl->pub_track) return;
-    if (!moq_pub_has_subscriber(s->pub, tl->pub_track)) return;
+    if (!sender_track_demand(s, tl)) return;
 
     uint64_t next_seq = tl->mt_base_seq + tl->mt_rec_count;
     while (tl->mt_lead < next_seq) {
@@ -1190,7 +1276,7 @@ static void sender_drain(moq_media_sender_t *s, uint64_t now_us)
             continue;
         }
 
-        bool has_sub = moq_pub_has_subscriber(s->pub, t->pub_track);
+        bool has_sub = sender_track_demand(s, t);
 
         /* Terminal marker: emit a reliable END_OF_TRACK after this track's
          * queued objects (FIFO preserves the ordering). The facade closes any
@@ -1226,16 +1312,12 @@ static void sender_drain(moq_media_sender_t *s, uint64_t now_us)
             continue;
         }
 
-        /* Ready is publish-path readiness, NOT subscriber presence: the
-         * facade silently no-ops a write with no active subscriber, so
-         * emitting now would discard the media. Hold the head until a
-         * subscriber (a relay, typically) exists for its track; the
-         * bounded queue + backpressure policy bound the wait. (FIFO hold:
-         * a subscriber-less track at the head also pauses tracks behind
-         * it -- acceptable for v0, where a relay subscribes to all
-         * advertised tracks together.) */
-        if (!has_sub)
+        /* No demand: the facade would no-op the write, so drop the queued media
+         * outright to stay at the live edge (head still blocks behind it, v0). */
+        if (!has_sub) {
+            preq_drop_all_for_track(s, t);
             break;
+        }
 
         /* A drop abandoned this track's open group: reset it on the wire
          * before emitting the next (newer) group. */
@@ -1352,8 +1434,23 @@ static void sender_add_pub_track(moq_media_sender_t *s, moq_media_track_t *t,
         ? (moq_bytes_t){ s->catalog_name, s->catalog_name_len }
         : t->name;
     tcfg.advertise_namespace = advertise;
-    if (moq_pub_add_track(s->pub, &tcfg, now_us, &t->pub_track) != MOQ_OK)
+
+    if (t->is_catalog) {
+        tcfg.has_publisher_priority = true;
+        tcfg.publisher_priority = 0;
+    }
+
+    if (moq_pub_add_track(s->pub, &tcfg, now_us, &t->pub_track) != MOQ_OK) {
         sender_set_fatal_locked(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+        return;
+    }
+
+    if (s->publish_tracks && t->pub_track) {
+        moq_pub_publish_cfg_t pcfg;
+        moq_pub_publish_cfg_init(&pcfg);
+        if (moq_pub_publish_track(s->pub, t->pub_track, &pcfg, now_us) != MOQ_OK)
+            sender_set_fatal_locked(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+    }
 }
 
 static bool rcbuf_bytes_eq(const moq_rcbuf_t *a, const moq_rcbuf_t *b)
@@ -1781,6 +1878,41 @@ static void sender_resync_demand(moq_media_sender_t *s)
     sender_tracks_release(s, snap, n);
 }
 
+static void sender_pub_on_closed(void *ctx, uint64_t error_code)
+{
+    (void)error_code;   /* the peer's session error is not the sender fatal code */
+    moq_media_sender_t *s = (moq_media_sender_t *)ctx;
+    sender_fire_closed(s, false, 0);
+}
+
+static void sender_pub_on_publish_finished(void *ctx, moq_pub_track_t *pt)
+{
+    moq_media_sender_t *s = (moq_media_sender_t *)ctx;
+
+    pthread_mutex_lock(&s->mu);
+
+    /* The catalog track is private (not in s->tracks[]); check it first. */
+    if (s->catalog_track && s->catalog_track->pub_track == pt) {
+        pthread_mutex_unlock(&s->mu);
+        sender_fire_closed(s, false, 0);   /* no catalog -> session is done */
+        return;
+    }
+
+    moq_media_track_t *t = NULL;
+    for (size_t i = 0; i < s->track_count; i++) {
+        if (s->tracks[i]->pub_track == pt) { t = s->tracks[i]; break; }
+    }
+    /* Fire once per track, for app-visible media only. */
+    bool fire = t && track_is_app_media(t) && !t->pub_closed_fired;
+    if (fire) t->pub_closed_fired = true;
+    void *cbctx = s->callbacks.ctx;
+    void (*cb)(void *, moq_media_sender_t *, moq_media_track_t *)
+        = s->callbacks.on_track_closed;
+    pthread_mutex_unlock(&s->mu);
+
+    if (fire && cb) cb(cbctx, s, t);
+}
+
 static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
                         uint64_t now_us, void *ctx)
 {
@@ -1789,8 +1921,13 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
 
     pthread_mutex_lock(&s->mu);
     bool fatal = s->fatal;
+    uint64_t fatal_code = s->fatal_code;
     pthread_mutex_unlock(&s->mu);
-    if (fatal || !session) return;
+    if (fatal) {
+        sender_fire_closed(s, true, fatal_code);
+        return;
+    }
+    if (!session) return;
 
     if (!s->pub) {
         if (moq_session_state(session) != MOQ_SESS_ESTABLISHED)
@@ -1799,10 +1936,9 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
         moq_pub_cfg_t pcfg;
         moq_pub_cfg_init_sized(&pcfg, sizeof(pcfg));
         pcfg.accept_mode = MOQ_PUB_ACCEPT_ALL;
-        /* Demand visibility (§7.2) is mirrored by polling
-         * moq_pub_active_subscriptions in sender_resync_demand (below), not by
-         * the core join/left callbacks -- those miss the clear-without-left
-         * paths (session close / finish). So no pub callbacks are installed. */
+        pcfg.callbacks.ctx = s;
+        pcfg.callbacks.on_closed = sender_pub_on_closed;
+        pcfg.callbacks.on_publish_finished = sender_pub_on_publish_finished;
         if (moq_pub_create(session, &s->alloc, &pcfg, &s->pub) != MOQ_OK) {
             sender_set_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
             return;
@@ -1821,11 +1957,25 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
         ccfg.track_namespace = s->namespace_;
         ccfg.track_name = (moq_bytes_t){ s->catalog_name, s->catalog_name_len };
         ccfg.advertise_namespace = true;
+        ccfg.has_publisher_priority = true;
+        ccfg.publisher_priority = 0;   /* catalog leads delivery */
         if (moq_pub_add_track(s->pub, &ccfg, now_us,
                               &s->catalog_track->pub_track) != MOQ_OK) {
             sender_set_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
             return;
         }
+        /* PUBLISH the catalog track (media tracks are published in
+         * sender_add_pub_track below). */
+        if (s->publish_tracks) {
+            moq_pub_publish_cfg_t cpcfg;
+            moq_pub_publish_cfg_init(&cpcfg);
+            if (moq_pub_publish_track(s->pub, s->catalog_track->pub_track,
+                                      &cpcfg, now_us) != MOQ_OK) {
+                sender_set_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+                return;
+            }
+        }
+
         /* Walk a snapshot so a concurrent app-thread realloc of s->tracks cannot
          * free the vector mid-walk; the per-track registration below takes s->mu
          * to decide and create the publisher track atomically. NOMEM here is
@@ -1901,14 +2051,37 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
      * callback in the same cycle it is accepted (before the drain runs). */
     sender_resync_demand(s);
 
-    /* Readiness: namespace accepted (catalog track carries the announce)
-     * AND the catalog is published. */
+    /* Publish-initiated: once the peer accepts the catalog PUBLISH, push the
+     * initial catalog object live so a relay caches it without a FETCH. */
+    if (s->publish_tracks && !s->live_catalog_sent && s->catalog_published &&
+        sender_track_demand(s, s->catalog_track) &&
+        s->published_catalog) {
+        moq_pub_object_cfg_t ocfg;
+        moq_pub_object_cfg_init(&ocfg);
+
+        /* Same (group 0, object 0) as the retained group: it is the same catalog
+         * object, so a live subscriber and a FETCH joiner see one identity. */
+        ocfg.group_id = 0;
+        ocfg.object_id = 0;
+        ocfg.payload = s->published_catalog;
+        ocfg.end_of_group = true;
+        moq_result_t wrc = moq_pub_write_object_ex(
+            s->pub, s->catalog_track->pub_track, &ocfg, now_us);
+        if (wrc == MOQ_OK)
+            s->live_catalog_sent = true;
+    }
+
+    /* Ready: catalog published AND accepted by the peer - via the namespace
+     * advertisement (pull) or the catalog's PUBLISH (publish). */
     if (!s->ready && s->catalog_published &&
-        moq_pub_namespace_accepted(s->pub, s->catalog_track->pub_track)) {
+        (moq_pub_namespace_accepted(s->pub, s->catalog_track->pub_track) ||
+         (s->publish_tracks &&
+          moq_pub_track_is_published(s->pub, s->catalog_track->pub_track)))) {
         pthread_mutex_lock(&s->mu);
         s->ready = true;
         pthread_cond_broadcast(&s->space_cv);  /* bound widened to queue_cap */
         pthread_mutex_unlock(&s->mu);
+        sender_fire_ready(s);
     }
 
     /* Post-ready track maintenance: tear down removed tracks (end-of-track, then
@@ -2581,8 +2754,21 @@ static moq_result_t sender_new(moq_endpoint_t *ep, bool owns,
                                         on_subscriber_left) +
                                    sizeof(cb->on_subscriber_left))
             s->callbacks.on_subscriber_left = cb->on_subscriber_left;
+        if (cb->struct_size >= offsetof(moq_media_sender_callbacks_t,
+                                        on_ready) + sizeof(cb->on_ready))
+            s->callbacks.on_ready = cb->on_ready;
+        if (cb->struct_size >= offsetof(moq_media_sender_callbacks_t,
+                                        on_closed) + sizeof(cb->on_closed))
+            s->callbacks.on_closed = cb->on_closed;
+        if (cb->struct_size >= offsetof(moq_media_sender_callbacks_t,
+                                        on_track_closed) +
+                                   sizeof(cb->on_track_closed))
+            s->callbacks.on_track_closed = cb->on_track_closed;
         s->callbacks.struct_size = sizeof(s->callbacks);
     }
+    if (cfg->struct_size >= offsetof(moq_media_sender_cfg_t, publish_tracks) +
+                                sizeof(cfg->publish_tracks))
+        s->publish_tracks = cfg->publish_tracks;
     s->block_timeout_us = cfg->block_timeout_us
         ? cfg->block_timeout_us : SENDER_DEFAULT_BLOCK_TIMEOUT_US;
     s->queue_cap = cfg->queue_max_objects
@@ -3626,7 +3812,12 @@ moq_media_sender_t *moq_media_sender_test_new(void)
 
 void moq_media_sender_test_free(moq_media_sender_t *s)
 {
-    if (s) sender_free(s);
+    if (!s) return;
+    /* A test may have lazily created the private catalog track (via
+     * moq_media_sender_test_catalog_track); sender_free does not own it (destroy
+     * does), so release it here to keep the test leak-free. */
+    if (s->catalog_track) { track_free(s, s->catalog_track); s->catalog_track = NULL; }
+    sender_free(s);
 }
 
 /* Force or clear the sender-fatal flag, so a wait-contract test can prove
@@ -3667,6 +3858,66 @@ void moq_media_sender_test_set_ready(moq_media_sender_t *s)
     pthread_mutex_lock(&s->mu);
     s->ready = true;
     pthread_mutex_unlock(&s->mu);
+}
+
+/* Install lifecycle callbacks on a test sender (no endpoint), so the fire
+ * seams below can be observed. Mirrors the negotiated copy sender_new does. */
+void moq_media_sender_test_set_callbacks(moq_media_sender_t *s,
+                                         const moq_media_sender_callbacks_t *cb)
+{
+    pthread_mutex_lock(&s->mu);
+    s->callbacks.ctx = cb->ctx;
+    s->callbacks.on_ready = cb->on_ready;
+    s->callbacks.on_closed = cb->on_closed;
+    s->callbacks.on_track_closed = cb->on_track_closed;
+    s->callbacks.struct_size = sizeof(s->callbacks);
+    pthread_mutex_unlock(&s->mu);
+}
+
+/* Drive the core on_publish_finished handler for a track, mapping by pub_track
+ * exactly as the network thread does. The test assigns the track a sentinel
+ * pub_track (its own address) so the production mapping loop resolves it; then
+ * the real handler runs (app-media filter + per-track latch + catalog->on_closed
+ * routing). Pass the catalog track to exercise the catalog-termination path. */
+void moq_media_sender_test_fire_publish_finished(moq_media_sender_t *s,
+                                                 moq_media_track_t *track)
+{
+    track->pub_track = (moq_pub_track_t *)track;   /* sentinel for the map */
+    sender_pub_on_publish_finished(s, track->pub_track);
+}
+
+/* Expose the catalog track handle so the test can drive its termination. */
+moq_media_track_t *moq_media_sender_test_catalog_track(moq_media_sender_t *s)
+{
+    if (!s->catalog_track) {
+        s->catalog_track = (moq_media_track_t *)s->alloc.alloc(
+            sizeof(moq_media_track_t), s->alloc.ctx);
+        if (s->catalog_track) {
+            memset(s->catalog_track, 0, sizeof(*s->catalog_track));
+            s->catalog_track->is_catalog = true;
+        }
+    }
+    return s->catalog_track;
+}
+
+/* Drive the PRODUCTION fire helpers (same code the network thread runs), so the
+ * test exercises the real single-fire latch + callback dispatch, not a copy. */
+void moq_media_sender_test_fire_ready(moq_media_sender_t *s)
+{
+    sender_fire_ready(s);
+}
+
+void moq_media_sender_test_fire_closed(moq_media_sender_t *s, bool is_fatal,
+                                       uint64_t fatal_code)
+{
+    sender_fire_closed(s, is_fatal, fatal_code);
+}
+
+/* Drive the fatal path end-to-end: sender_set_fatal marks fatal AND fires
+ * on_closed(is_fatal=true) inline, exactly as a network-thread fatal does. */
+void moq_media_sender_test_fire_fatal(moq_media_sender_t *s, uint64_t code)
+{
+    sender_set_fatal(s, code);
 }
 
 /* Simulate complete() state without an endpoint: set completing + mark every

--- a/service/tests/test_media_sender.c
+++ b/service/tests/test_media_sender.c
@@ -2203,6 +2203,74 @@ int main(int argc, char **argv)
         moq_pq_threaded_destroy(srv);
     }
 
+    /* == no subscriber, drop_without_demand: stay at the live edge ==== *
+     * Media written without demand is dropped (counted); a later
+     * subscriber receives only media written after it joined. */
+    {
+        int port = 0;
+        memset(&g_srv, 0, sizeof(g_srv));
+        g_srv.no_subscribe = true;
+        moq_pq_threaded_t *srv = start_server(cert, key, &g_srv, &port);
+        MOQ_TEST_CHECK(srv != NULL);
+        if (!srv) return 1;
+        char url[64];
+        moq_endpoint_cfg_t ec = ep_cfg(url, sizeof(url), port);
+        moq_bytes_t parts[2];
+        moq_media_sender_cfg_t cfg;
+        fill_cfg(&cfg, parts);           /* DROP_TO_KEYFRAME, big default bound */
+        cfg.endpoint = &ec;
+        cfg.drop_without_demand = true;
+        moq_media_sender_t *s = NULL;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_media_sender_create(&cfg, &s),
+                              (int)MOQ_OK);
+        moq_media_track_t *v = NULL;
+        add_video_track(s, &v);
+        MOQ_TEST_CHECK(wait_ready(s, 300));
+        MOQ_TEST_CHECK(atomic_load(&g_srv.ns_accepted));
+
+        /* A full GOP written with no demand: dropped, not held. */
+        for (int i = 0; i < 3; i++) {
+            moq_rcbuf_t *b = mkbuf(16, (uint8_t)i);
+            moq_media_send_object_t o = mkobj(b, i == 0, i == 0, i == 2);
+            moq_result_t rc = moq_media_sender_write(s, v, &o);
+            if (rc != MOQ_OK) moq_rcbuf_decref(b);
+            MOQ_TEST_CHECK_EQ_INT((int)rc, (int)MOQ_OK);
+        }
+        moq_media_sender_stats_t st;
+        for (int i = 0; i < 200; i++) {
+            (void)moq_media_sender_get_stats(s, &st, sizeof(st));
+            if (st.objects_dropped >= 3 && st.objects_queued == 0) break;
+            usleep(50000);
+        }
+        MOQ_TEST_CHECK_EQ_U64(st.objects_dropped, 3);
+        MOQ_TEST_CHECK_EQ_U64(st.objects_queued, 0);
+        MOQ_TEST_CHECK_EQ_U64(st.objects_sent, 0);
+
+        /* Demand appears: only the fresh GOP written afterwards reaches the
+         * subscriber; the pre-demand GOP is gone. */
+        g_srv.no_subscribe = false;
+        for (int i = 0; i < 200 && !moq_media_sender_track_has_subscriber(s, v);
+             i++)
+            usleep(50000);
+        MOQ_TEST_CHECK(moq_media_sender_track_has_subscriber(s, v));
+        for (int i = 0; i < 3; i++) {
+            moq_rcbuf_t *b = mkbuf(16, (uint8_t)(0x10 + i));
+            moq_media_send_object_t o = mkobj(b, i == 0, i == 0, i == 2);
+            moq_result_t rc = moq_media_sender_write(s, v, &o);
+            if (rc != MOQ_OK) moq_rcbuf_decref(b);
+            MOQ_TEST_CHECK_EQ_INT((int)rc, (int)MOQ_OK);
+        }
+        for (int i = 0; i < 200 && srv_count(&g_srv) < 3; i++) usleep(50000);
+        MOQ_TEST_CHECK_EQ_INT(srv_count(&g_srv), 3);   /* fresh GOP only */
+        (void)moq_media_sender_get_stats(s, &st, sizeof(st));
+        MOQ_TEST_CHECK(st.objects_sent >= 3);
+        MOQ_TEST_CHECK_EQ_U64(st.objects_dropped, 3);  /* no further drops */
+
+        moq_media_sender_destroy(s);
+        moq_pq_threaded_stop(srv);
+        moq_pq_threaded_destroy(srv);
+    }
+
     /* == terminal: a fatal handshake makes write return CLOSED ========= *
      * EXACT draft-18 against a draft-16-only server fails fatally. Two
      * race-equivalent terminal outcomes, both correct: create() may refuse

--- a/service/tests/test_media_sender.c
+++ b/service/tests/test_media_sender.c
@@ -869,6 +869,34 @@ static void demand_on_left(void *ctx, moq_media_sender_t *sender,
     atomic_fetch_add(&d->leaves, 1);
 }
 
+/* -- Lifecycle (on_ready / on_closed) callback capture ---------------- *
+ * Same memory-ordering scheme as the demand capture: the payload fields are
+ * written before the seq-cst counter increment, so the test thread reads
+ * them safely once it observes the increment. */
+typedef struct {
+    atomic_int ready_calls;
+    atomic_int closed_calls;
+    bool       closed_is_fatal;
+    uint64_t   closed_code;
+} lifecycle_state_t;
+static lifecycle_state_t g_life;
+
+static void life_on_ready(void *ctx, moq_media_sender_t *sender)
+{
+    (void)sender;
+    atomic_fetch_add(&((lifecycle_state_t *)ctx)->ready_calls, 1);
+}
+
+static void life_on_closed(void *ctx, moq_media_sender_t *sender,
+                           bool is_fatal, uint64_t fatal_code)
+{
+    lifecycle_state_t *l = (lifecycle_state_t *)ctx;
+    (void)sender;
+    l->closed_is_fatal = is_fatal;
+    l->closed_code = fatal_code;
+    atomic_fetch_add(&l->closed_calls, 1);
+}
+
 /* -- CMAF object/init builders for the validate_cmaf tests ----------- */
 
 static void wr32be(uint8_t *p, uint32_t v)
@@ -4485,6 +4513,67 @@ int main(int argc, char **argv)
         moq_media_sender_destroy(s);
         moq_pq_threaded_stop(srv);
         moq_pq_threaded_destroy(srv);
+    }
+
+    /* == on_closed fires for an endpoint-level connect failure ========= *
+     * TLS certificate verification failure: insecure_skip_verify=false
+     * against the loopback server's self-signed cert. The handshake fails
+     * fatally with NO session ever established, so the publisher was never
+     * created and its callbacks cannot surface the death -- only the sender
+     * hook's endpoint-terminal check can. Before that check existed, a
+     * callbacks-only app never learned the sender was dead (only the
+     * polling queries saw endpoint state) and waited on on_ready forever.
+     * Cert-verify (not ALPN mismatch) is the failure vector on purpose: it
+     * needs the full first round trip, so create()+attach (microseconds)
+     * reliably completes BEFORE the failure lands and the hook path -- not
+     * the synchronous attach-gate path -- is what gets exercised. */
+    {
+        int port = 0;
+        memset(&g_srv, 0, sizeof(g_srv));
+        moq_pq_threaded_t *srv = start_server(cert, key, &g_srv, &port);
+        MOQ_TEST_CHECK(srv != NULL);
+        if (!srv) return 1;
+
+        char url[64];
+        moq_endpoint_cfg_t ec = ep_cfg(url, sizeof(url), port);
+        ec.insecure_skip_verify = false;   /* real verification: must fail */
+
+        moq_bytes_t parts[2];
+        moq_media_sender_cfg_t cfg;
+        fill_cfg(&cfg, parts);
+        cfg.endpoint = &ec;
+        memset(&g_life, 0, sizeof(g_life));
+        moq_media_sender_callbacks_init(&cfg.callbacks);
+        cfg.callbacks.ctx = &g_life;
+        cfg.callbacks.on_ready = life_on_ready;
+        cfg.callbacks.on_closed = life_on_closed;
+
+        /* If the failure ever beats create() (attach gate -> MOQ_ERR_CLOSED,
+         * a polling-visible outcome, also correct), don't fail the test --
+         * but the expected path is create() OK + on_closed from the hook. */
+        moq_media_sender_t *s = NULL;
+        moq_result_t crc = moq_media_sender_create(&cfg, &s);
+        if (crc == MOQ_OK) {
+            /* The handshake failure is quick; the 10s ceiling is a backstop. */
+            for (int i = 0; i < 200 && atomic_load(&g_life.closed_calls) == 0;
+                 i++)
+                usleep(50000);
+            MOQ_TEST_CHECK_EQ_INT(atomic_load(&g_life.closed_calls), 1);
+            MOQ_TEST_CHECK(g_life.closed_is_fatal);
+            MOQ_TEST_CHECK_EQ_INT(atomic_load(&g_life.ready_calls), 0);
+            /* The callback agrees with the polling queries. */
+            MOQ_TEST_CHECK(moq_media_sender_is_fatal(s));
+            MOQ_TEST_CHECK(moq_media_sender_is_closed(s));
+            moq_media_sender_destroy(s);
+        } else {
+            MOQ_TEST_CHECK_EQ_INT((int)crc, (int)MOQ_ERR_CLOSED);
+            MOQ_TEST_CHECK(s == NULL);
+            printf("note: connect failure preempted create(); "
+                   "hook path not exercised this run\n");
+        }
+        moq_pq_threaded_stop(srv);
+        moq_pq_threaded_destroy(srv);
+        MOQ_TEST_PASS("media_sender.on_closed_connect_failure");
     }
 
     MOQ_TEST_PASS("media_sender");

--- a/service/tests/test_media_sender_lifecycle.c
+++ b/service/tests/test_media_sender_lifecycle.c
@@ -1,0 +1,259 @@
+/*
+ * White-box tests for the sender's lifecycle callbacks (on_ready / on_closed),
+ * deterministic and with no network. They drive the PRODUCTION fire helpers via
+ * the test seam -- the same sender_fire_ready / sender_fire_closed the network
+ * thread runs -- so the single-fire latch, the fatal-vs-clean flag, and the
+ * callback dispatch are exercised exactly as in the shipping path. The
+ * end-to-end wire behavior (a real relay accepting the publication, a peer
+ * closing the session) is covered separately by the loopback tests in
+ * test_media_sender.c, which need the network adapter.
+ */
+#include <moq/media_sender.h>
+#include <moq/rcbuf.h>
+#include "test_support.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+static int failures = 0;
+
+/* Test seam (media_sender.c, MOQ_MEDIA_SENDER_TESTING). */
+moq_media_sender_t *moq_media_sender_test_new(void);
+void moq_media_sender_test_free(moq_media_sender_t *s);
+void moq_media_sender_test_set_callbacks(moq_media_sender_t *s,
+                                         const moq_media_sender_callbacks_t *cb);
+void moq_media_sender_test_fire_ready(moq_media_sender_t *s);
+void moq_media_sender_test_fire_closed(moq_media_sender_t *s, bool is_fatal,
+                                       uint64_t fatal_code);
+void moq_media_sender_test_fire_fatal(moq_media_sender_t *s, uint64_t code);
+void moq_media_sender_test_fire_publish_finished(moq_media_sender_t *s,
+                                                 moq_media_track_t *track);
+moq_media_track_t *moq_media_sender_test_catalog_track(moq_media_sender_t *s);
+
+/* Add an app-visible RAW video track to a test sender (returns its handle). */
+static moq_media_track_t *add_video(moq_media_sender_t *s, const char *name)
+{
+    moq_media_track_cfg_t tc;
+    moq_media_track_cfg_init(&tc);
+    tc.name = (moq_bytes_t){ (const uint8_t *)name, strlen(name) };
+    tc.media_type = MOQ_MEDIA_TYPE_VIDEO;
+    tc.packaging = MOQ_MEDIA_PACKAGING_RAW;
+    tc.codec = (moq_bytes_t){ (const uint8_t *)"av01", 4 };
+    tc.bitrate = 1500000;
+    tc.is_live = true;
+    moq_media_track_t *t = NULL;
+    MOQ_TEST_CHECK_EQ_INT(
+        (int)moq_media_sender_add_track(s, &tc, &t), (int)MOQ_OK);
+    return t;
+}
+
+/* -- Callback observers ----------------------------------------------- */
+
+struct obs {
+    int      ready_calls;
+    void    *ready_ctx;
+    moq_media_sender_t *ready_sender;
+
+    int      closed_calls;
+    void    *closed_ctx;
+    bool     closed_is_fatal;
+    uint64_t closed_code;
+
+    int                 track_closed_calls;
+    moq_media_track_t  *track_closed_last;
+};
+
+static void on_ready_cb(void *ctx, moq_media_sender_t *sender)
+{
+    struct obs *o = (struct obs *)ctx;
+    o->ready_calls++;
+    o->ready_ctx = ctx;
+    o->ready_sender = sender;
+}
+
+static void on_closed_cb(void *ctx, moq_media_sender_t *sender,
+                         bool is_fatal, uint64_t fatal_code)
+{
+    (void)sender;
+    struct obs *o = (struct obs *)ctx;
+    o->closed_calls++;
+    o->closed_ctx = ctx;
+    o->closed_is_fatal = is_fatal;
+    o->closed_code = fatal_code;
+}
+
+static void on_track_closed_cb(void *ctx, moq_media_sender_t *sender,
+                               moq_media_track_t *track)
+{
+    (void)sender;
+    struct obs *o = (struct obs *)ctx;
+    o->track_closed_calls++;
+    o->track_closed_last = track;
+}
+
+static void install(moq_media_sender_t *s, struct obs *o)
+{
+    moq_media_sender_callbacks_t cb;
+    moq_media_sender_callbacks_init(&cb);
+    cb.ctx = o;
+    cb.on_ready = on_ready_cb;
+    cb.on_closed = on_closed_cb;
+    cb.on_track_closed = on_track_closed_cb;
+    moq_media_sender_test_set_callbacks(s, &cb);
+}
+
+int main(void)
+{
+    /* on_ready fires exactly once, with the registered ctx + sender handle,
+     * and does not re-fire on a second edge (latch). */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        MOQ_TEST_CHECK(s != NULL);
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+
+        moq_media_sender_test_fire_ready(s);
+        MOQ_TEST_CHECK_EQ_INT(o.ready_calls, 1);
+        MOQ_TEST_CHECK(o.ready_ctx == &o);
+        MOQ_TEST_CHECK(o.ready_sender == s);
+
+        moq_media_sender_test_fire_ready(s);   /* second edge: latched */
+        MOQ_TEST_CHECK_EQ_INT(o.ready_calls, 1);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_ready_fires_once");
+    }
+
+    /* A clean close surfaces on_closed(is_fatal=false, code=0), once. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+
+        moq_media_sender_test_fire_closed(s, false, 0);
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);
+        MOQ_TEST_CHECK(o.closed_is_fatal == false);
+        MOQ_TEST_CHECK_EQ_INT((int)o.closed_code, 0);
+
+        moq_media_sender_test_fire_closed(s, false, 0);   /* latched */
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_closed_clean");
+    }
+
+    /* The fatal path (sender_set_fatal) marks fatal AND fires
+     * on_closed(is_fatal=true) inline with the sender's fatal code. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+
+        moq_media_sender_test_fire_fatal(s, MOQ_MEDIA_SENDER_FATAL_CATALOG_ENCODE);
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);
+        MOQ_TEST_CHECK(o.closed_is_fatal == true);
+        MOQ_TEST_CHECK_EQ_INT((int)o.closed_code,
+                              (int)MOQ_MEDIA_SENDER_FATAL_CATALOG_ENCODE);
+
+        /* A second fatal (e.g. a later distinct failure) does not re-fire. */
+        moq_media_sender_test_fire_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_closed_fatal");
+    }
+
+    /* Cross-path latch: whichever terminal edge lands first wins. A fatal that
+     * fired first is not overridden by a later clean-close edge. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+
+        moq_media_sender_test_fire_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+        moq_media_sender_test_fire_closed(s, false, 0);   /* loses the race */
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);
+        MOQ_TEST_CHECK(o.closed_is_fatal == true);        /* still the fatal */
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_closed_latch_first_wins");
+    }
+
+    /* A peer terminating an app track's publication surfaces on_track_closed
+     * once for THAT track (mapped by pub_track), latched, and does NOT fire the
+     * session on_closed. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+        moq_media_track_t *v = add_video(s, "video");
+
+        moq_media_sender_test_fire_publish_finished(s, v);
+        MOQ_TEST_CHECK_EQ_INT(o.track_closed_calls, 1);
+        MOQ_TEST_CHECK(o.track_closed_last == v);
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 0);  /* session still alive */
+
+        moq_media_sender_test_fire_publish_finished(s, v);   /* repeat: latched */
+        MOQ_TEST_CHECK_EQ_INT(o.track_closed_calls, 1);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_track_closed_app");
+    }
+
+    /* Two app tracks terminate independently: each fires once, for its own
+     * handle. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+        moq_media_track_t *v = add_video(s, "video");
+        moq_media_track_t *a = add_video(s, "audio");
+
+        moq_media_sender_test_fire_publish_finished(s, v);
+        MOQ_TEST_CHECK_EQ_INT(o.track_closed_calls, 1);
+        MOQ_TEST_CHECK(o.track_closed_last == v);
+        moq_media_sender_test_fire_publish_finished(s, a);
+        MOQ_TEST_CHECK_EQ_INT(o.track_closed_calls, 2);
+        MOQ_TEST_CHECK(o.track_closed_last == a);
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 0);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.on_track_closed_two_tracks");
+    }
+
+    /* Terminating the internal CATALOG track's publication does NOT fire
+     * on_track_closed (it is not app media) -- it surfaces the session on_closed
+     * (clean), because without a catalog the sender cannot operate. */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        struct obs o; memset(&o, 0, sizeof(o));
+        install(s, &o);
+        moq_media_track_t *cat = moq_media_sender_test_catalog_track(s);
+        MOQ_TEST_CHECK(cat != NULL);
+
+        moq_media_sender_test_fire_publish_finished(s, cat);
+        MOQ_TEST_CHECK_EQ_INT(o.track_closed_calls, 0);   /* not app media */
+        MOQ_TEST_CHECK_EQ_INT(o.closed_calls, 1);         /* session done */
+        MOQ_TEST_CHECK(o.closed_is_fatal == false);
+
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.catalog_finished_is_close");
+    }
+
+    /* No callbacks registered: firing the edges is a safe no-op (no crash). */
+    {
+        moq_media_sender_t *s = moq_media_sender_test_new();
+        moq_media_track_t *v = add_video(s, "video");
+        moq_media_sender_test_fire_ready(s);
+        moq_media_sender_test_fire_publish_finished(s, v);
+        moq_media_sender_test_fire_fatal(s, MOQ_MEDIA_SENDER_FATAL_SETUP_FAILED);
+        moq_media_sender_test_fire_closed(s, false, 0);
+        moq_media_sender_test_free(s);
+        MOQ_TEST_PASS("sender_lifecycle.no_callbacks_safe");
+    }
+
+    printf("%s: %d failures\n", failures ? "FAIL" : "PASS", failures);
+    return failures ? 1 : 0;
+}

--- a/tests/unit/test_publisher.c
+++ b/tests/unit/test_publisher.c
@@ -7209,6 +7209,195 @@ static void test_ns_refcount_would_block_retry(void) {
     MOQ_TEST_PASS("ns_refcount_would_block_retry");
 }
 
+/* -- Publisher-initiated PUBLISH ---------------------------------- */
+
+/* On the client (the subscriber side of the simpair), drain one
+ * PUBLISH_REQUEST and accept it, optionally forcing the forward flag. Returns
+ * true if a request was accepted. */
+static bool client_accept_publish(moq_simpair_t *sp) {
+    moq_event_t ev;
+    if (moq_session_poll_events(moq_simpair_client(sp), &ev, 1) != 1)
+        return false;
+    bool accepted = false;
+    if (ev.kind == MOQ_EVENT_PUBLISH_REQUEST) {
+        moq_accept_publish_cfg_t acc;
+        moq_accept_publish_cfg_init(&acc);
+        moq_result_t rc = moq_session_accept_publish(moq_simpair_client(sp),
+            ev.u.publish_request.pub, &acc, moq_simpair_now_us(sp));
+        MOQ_TEST_CHECK(rc == MOQ_OK);
+        accepted = true;
+    }
+    moq_event_cleanup(&ev);
+    return accepted;
+}
+
+static void test_publish_track_accepted(void) {
+    test_alloc_state_t as; moq_alloc_t alloc; moq_simpair_t *sp;
+    simpair_setup(&as, &alloc, &sp);
+
+    moq_pub_cfg_t cfg; moq_pub_cfg_init(&cfg);
+    cfg.accept_mode = MOQ_PUB_ACCEPT_ALL;
+    moq_publisher_t *pub = NULL;
+    moq_pub_create(moq_simpair_server(sp), &alloc, &cfg, &pub);
+
+    moq_pub_track_cfg_t tcfg; moq_pub_track_cfg_init(&tcfg);
+    moq_bytes_t ns_parts[] = { MOQ_BYTES_LITERAL("live") };
+    tcfg.track_namespace.parts = ns_parts; tcfg.track_namespace.count = 1;
+    tcfg.track_name = MOQ_BYTES_LITERAL("video");
+    moq_pub_track_t *track = NULL;
+    MOQ_TEST_CHECK(moq_pub_add_track(pub, &tcfg,
+        moq_simpair_now_us(sp), &track) == MOQ_OK);
+
+    /* Publish the track (publisher-initiated PUBLISH). */
+    moq_pub_publish_cfg_t pcfg; moq_pub_publish_cfg_init(&pcfg);
+    MOQ_TEST_CHECK(moq_pub_publish_track(pub, track,
+        &pcfg, moq_simpair_now_us(sp)) == MOQ_OK);
+    MOQ_TEST_CHECK(!moq_pub_track_is_published(pub, track));
+
+    /* Client receives PUBLISH and accepts -> PUBLISH_OK. */
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    MOQ_TEST_CHECK(client_accept_publish(sp));
+
+    /* Server tick consumes PUBLISH_OK -> published, forward defaults true. */
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    MOQ_TEST_CHECK(moq_pub_tick(pub, moq_simpair_now_us(sp)) == MOQ_OK);
+    MOQ_TEST_CHECK(moq_pub_track_is_published(pub, track));
+    MOQ_TEST_CHECK(moq_pub_track_forward(pub, track));
+
+    /* Idempotent: a second publish_track is a no-op MOQ_OK. */
+    MOQ_TEST_CHECK(moq_pub_publish_track(pub, track,
+        &pcfg, moq_simpair_now_us(sp)) == MOQ_OK);
+
+    /* A published track is NOT counted as a subscriber. */
+    MOQ_TEST_CHECK(moq_pub_active_subscriptions(pub, track) == 0);
+    MOQ_TEST_CHECK(!moq_pub_has_subscriber(pub, track));
+
+    moq_pub_destroy(pub);
+    drain_all(sp);
+    moq_simpair_destroy(sp);
+    MOQ_TEST_CHECK(as.balance == 0);
+    MOQ_TEST_PASS("publish_track_accepted");
+}
+
+/* Write objects on a published track: they must reach the publication's data
+ * stream (the write fan-out routes to the publication slot). */
+static void test_publish_track_write(void) {
+    test_alloc_state_t as; moq_alloc_t alloc; moq_simpair_t *sp;
+    simpair_setup(&as, &alloc, &sp);
+
+    moq_pub_cfg_t cfg; moq_pub_cfg_init(&cfg);
+    cfg.accept_mode = MOQ_PUB_ACCEPT_ALL;
+    moq_publisher_t *pub = NULL;
+    moq_pub_create(moq_simpair_server(sp), &alloc, &cfg, &pub);
+
+    moq_pub_track_cfg_t tcfg; moq_pub_track_cfg_init(&tcfg);
+    moq_bytes_t ns_parts[] = { MOQ_BYTES_LITERAL("live") };
+    tcfg.track_namespace.parts = ns_parts; tcfg.track_namespace.count = 1;
+    tcfg.track_name = MOQ_BYTES_LITERAL("video");
+    moq_pub_track_t *track = NULL;
+    moq_pub_add_track(pub, &tcfg, moq_simpair_now_us(sp), &track);
+
+    moq_pub_publish_cfg_t pcfg; moq_pub_publish_cfg_init(&pcfg);
+    moq_pub_publish_track(pub, track, &pcfg, moq_simpair_now_us(sp));
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    MOQ_TEST_CHECK(client_accept_publish(sp));
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    moq_pub_tick(pub, moq_simpair_now_us(sp));
+    MOQ_TEST_CHECK(moq_pub_track_is_published(pub, track));
+
+    /* Write one object; routed to the publication slot. */
+    moq_rcbuf_t *payload = NULL;
+    moq_rcbuf_create(&alloc, (const uint8_t *)"abcd", 4, &payload);
+    moq_result_t rc = moq_pub_write_object(pub, track, 0, 0, payload,
+        moq_simpair_now_us(sp));
+    MOQ_TEST_CHECK(rc == MOQ_OK);
+    moq_rcbuf_decref(payload);
+
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+
+    /* end_track on a published track finishes the publication (PUBLISH_DONE). */
+    rc = moq_pub_end_track(pub, track, moq_simpair_now_us(sp));
+    MOQ_TEST_CHECK(rc == MOQ_OK);
+    MOQ_TEST_CHECK(!moq_pub_track_is_published(pub, track));
+
+    moq_pub_destroy(pub);
+    drain_all(sp);
+    moq_simpair_destroy(sp);
+    MOQ_TEST_CHECK(as.balance == 0);
+    MOQ_TEST_PASS("publish_track_write");
+}
+
+/* Coexistence: one track is BOTH advertised (receives SUBSCRIBE) AND published.
+ * Proves PUBLISH is an operation, not an exclusive mode. */
+static void test_publish_and_subscribe_coexist(void) {
+    test_alloc_state_t as; moq_alloc_t alloc; moq_simpair_t *sp;
+    simpair_setup(&as, &alloc, &sp);
+
+    moq_pub_cfg_t cfg; moq_pub_cfg_init(&cfg);
+    cfg.accept_mode = MOQ_PUB_ACCEPT_ALL;
+    moq_publisher_t *pub = NULL;
+    moq_pub_create(moq_simpair_server(sp), &alloc, &cfg, &pub);
+
+    moq_pub_track_cfg_t tcfg; moq_pub_track_cfg_init(&tcfg);
+    moq_bytes_t ns_parts[] = { MOQ_BYTES_LITERAL("live") };
+    tcfg.track_namespace.parts = ns_parts; tcfg.track_namespace.count = 1;
+    tcfg.track_name = MOQ_BYTES_LITERAL("video");
+    tcfg.advertise_namespace = true;          /* announce ... */
+    moq_pub_track_t *track = NULL;
+    moq_pub_add_track(pub, &tcfg, moq_simpair_now_us(sp), &track);
+
+    /* ... AND publish the same track. */
+    moq_pub_publish_cfg_t pcfg; moq_pub_publish_cfg_init(&pcfg);
+    MOQ_TEST_CHECK(moq_pub_publish_track(pub, track,
+        &pcfg, moq_simpair_now_us(sp)) == MOQ_OK);
+
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+
+    /* Client accepts the namespace and the publish, in whatever order they
+     * surface; drain its event queue. */
+    for (int i = 0; i < 4; i++) {
+        moq_event_t ev;
+        if (moq_session_poll_events(moq_simpair_client(sp), &ev, 1) != 1)
+            break;
+        if (ev.kind == MOQ_EVENT_NAMESPACE_PUBLISHED) {
+            moq_accept_namespace_cfg_t nacc;
+            moq_accept_namespace_cfg_init(&nacc);
+            moq_session_accept_namespace(moq_simpair_client(sp),
+                ev.u.namespace_published.ann, &nacc, moq_simpair_now_us(sp));
+        } else if (ev.kind == MOQ_EVENT_PUBLISH_REQUEST) {
+            moq_accept_publish_cfg_t acc;
+            moq_accept_publish_cfg_init(&acc);
+            moq_session_accept_publish(moq_simpair_client(sp),
+                ev.u.publish_request.pub, &acc, moq_simpair_now_us(sp));
+        }
+        moq_event_cleanup(&ev);
+    }
+
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    MOQ_TEST_CHECK(moq_pub_tick(pub, moq_simpair_now_us(sp)) == MOQ_OK);
+    MOQ_TEST_CHECK(moq_pub_namespace_accepted(pub, track));
+    MOQ_TEST_CHECK(moq_pub_track_is_published(pub, track));
+
+    /* Now a SUBSCRIBE for the same track is also accepted (coexists). */
+    moq_subscribe_cfg_t scfg; moq_subscribe_cfg_init(&scfg);
+    scfg.track_namespace.parts = ns_parts; scfg.track_namespace.count = 1;
+    scfg.track_name = MOQ_BYTES_LITERAL("video");
+    moq_subscription_t sub_h;
+    MOQ_TEST_CHECK(moq_session_subscribe(moq_simpair_client(sp), &scfg,
+        moq_simpair_now_us(sp), &sub_h) == MOQ_OK);
+    moq_simpair_run_until_quiescent(sp, 8, NULL);
+    MOQ_TEST_CHECK(moq_pub_tick(pub, moq_simpair_now_us(sp)) == MOQ_OK);
+
+    MOQ_TEST_CHECK(moq_pub_has_subscriber(pub, track));     /* subscription slot */
+    MOQ_TEST_CHECK(moq_pub_track_is_published(pub, track)); /* publication intact */
+
+    moq_pub_destroy(pub);
+    drain_all(sp);
+    moq_simpair_destroy(sp);
+    MOQ_TEST_CHECK(as.balance == 0);
+    MOQ_TEST_PASS("publish_and_subscribe_coexist");
+}
+
 int main(void) {
     test_create_destroy();
     test_pub_cfg_init_old_prefix_no_overflow();
@@ -7313,6 +7502,9 @@ int main(void) {
     test_ns_refcount_shared();
     test_ns_refcount_distinct();
     test_ns_refcount_would_block_retry();
+    test_publish_track_accepted();
+    test_publish_track_write();
+    test_publish_and_subscribe_coexist();
 
     /* == end_of_group ABI: old struct_size must not read end_of_group == */
     {


### PR DESCRIPTION
Adds a publisher-initiated (push) contribution path across the core publisher and the media sender, plus supporting lifecycle callbacks and adapter fixes.

### 1. Lifecycle callbacks (core publisher + media sender)

**Core publisher** callbacks:
- `on_publish_ok` / `on_publish_error` / `on_publish_forward_changed` /   `on_publish_finished`, mapped from the PUBLISH_OK/ERROR/UPDATED/FINISHED events.

**Media sender** callbacks:
- `on_ready`: fires once when the sender is operative (namespace accepted +  catalog published).
- `on_closed`: fires once when the session reaches a terminal state;   `is_fatal` distinguishes a clean close from a failure.
- `on_track_closed`: fires when the peer terminates one app-media track's   publication while the session stays alive.

### 2. Publisher-initiated PUBLISH / push contribution

A track can now be **published** to the peer (PUBLISH), in addition to being advertised and answering SUBSCRIBE, the two coexist on the same track.

**Core publisher:**
- `moq_pub_publish_track` / `moq_pub_unpublish_track` and per-track publication state.
- Fan-out slots gain a `kind` (subscription vs publication); the object write path routes to either through the shared subgroup handle.
- `end_track` / `remove_track` terminate the publication with PUBLISH_DONE; `remove_track` resets an open publication subgroup (abrupt teardown), `unpublish_track` closes it cleanly.

**Media sender**  new `publish_tracks` cfg flag (default false):
- When true, PUBLISHes every track and emits the initial catalog object live so a relay caches it without a FETCH.
- Demand is generalized: a track wants data when it has a subscriber (pull) OR the publication is established with forward on (push).
- No-demand tracks now **drop their queued media outright** to stay at the live edge, instead of holding a backlog that would flush stale frames when demand returns.


### 3. picoquic / WebTransport adapter fixes

- **Transport-close propagation (WT client path):** picohttp/h3zero consumes a QUIC CONNECTION_CLOSE internally and emits no deregister capsule, so the bridge never learned of the close and `MOQ_EVENT_SESSION_CLOSED` never fired.
  The managed loop now detects the disconnected QUIC state (session already live) and propagates it into the bridge as a clean close, via the new `moq_pico_wt_conn_notify_transport_closed`. Mirrors the raw-QUIC adapter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/1)
<!-- Reviewable:end -->
