### PR TITLE
cmaf: skip prft/emsg/styp/sidx ahead of a chunk's moof

### DIFF
--- a/media/cmaf/src/cmaf.c
+++ b/media/cmaf/src/cmaf.c
@@ -635,8 +635,21 @@ moq_result_t moq_cmaf_parse_fragment(moq_bytes_t fragment,
         uint32_t type = box_type(fragment.data + pos);
 
         if (expect_moof) {
-            /* A CMAF chunk starts with a moof; anything else here (mdat first,
-             * a second moof, styp, ...) is not a successive moof+mdat chunk. */
+            /* A CMAF chunk starts with a moof, but ISO/IEC 23000-19 permits
+             * prft and emsg boxes ahead of it (and a fragment may lead with
+             * styp/sidx). They are metadata, not chunk structure -- skip
+             * them rather than reject the object, for interop with real
+             * publishers that emit them (ffmpeg -write_prft; moqtail's
+             * testsrc prefixes every chunk with a prft latency anchor).
+             * Anything else here (mdat first, a second moof, free, ...) is
+             * still not a successive moof+mdat chunk. */
+            if (type == FOURCC('p','r','f','t') ||
+                type == FOURCC('e','m','s','g') ||
+                type == FOURCC('s','t','y','p') ||
+                type == FOURCC('s','i','d','x')) {
+                pos += b.size;
+                continue;
+            }
             if (type != FOURCC('m','o','o','f'))
                 return MOQ_ERR_PROTO;
 
@@ -774,8 +787,18 @@ moq_result_t moq_cmaf_validate_object(const moq_cmaf_init_info_t *init,
         uint32_t type = box_type(object.data + pos);
 
         if (expect_moof) {
-            /* A chunk must START with a moof; anything else (mdat first, a
-             * second moof, styp, free, ...) breaks the successive-chunk rule. */
+            /* A chunk must START with a moof, but ISO/IEC 23000-19 permits
+             * prft/emsg (and a leading styp/sidx) ahead of it -- skip those
+             * (see the matching skip in moq_cmaf_parse_fragment). Anything
+             * else (mdat first, a second moof, free, ...) breaks the
+             * successive-chunk rule. */
+            if (type == FOURCC('p','r','f','t') ||
+                type == FOURCC('e','m','s','g') ||
+                type == FOURCC('s','t','y','p') ||
+                type == FOURCC('s','i','d','x')) {
+                pos += b.size;
+                continue;
+            }
             if (type != FOURCC('m','o','o','f')) {
                 reason = MOQ_CMAF_ERR_MALFORMED; break;
             }

--- a/media/cmaf/tests/test_cmaf.c
+++ b/media/cmaf/tests/test_cmaf.c
@@ -1420,6 +1420,70 @@ int main(void)
               == MOQ_ERR_PROTO);
     }
 
+    /* -- 42. prft/emsg/styp ahead of a chunk's moof are skipped ------- *
+     * ISO/IEC 23000-19 permits prft and emsg boxes in CMAF chunks ahead
+     * of the moof (and a fragment may lead with styp); real publishers
+     * emit them (ffmpeg -write_prft, moqtail's testsrc prefixes every
+     * chunk with a prft). They are metadata, not chunk-ordering
+     * violations -- skip them in parse_fragment and validate_object.
+     * Unknown boxes (e.g. free) still reject. */
+    {
+        /* prft: fullbox, reference_track_ID + ntp (8) + media time (4). */
+        uint8_t obj[256]; size_t n = 0;
+        n += box_hdr(obj + n, 8 + 4 + 4 + 8 + 4, "prft");
+        wr32(obj + n, 0); n += 4;              /* version + flags */
+        wr32(obj + n, 1); n += 4;              /* reference_track_ID */
+        wr32(obj + n, 0); n += 4;              /* ntp_timestamp hi */
+        wr32(obj + n, 0); n += 4;              /* ntp_timestamp lo */
+        wr32(obj + n, 0); n += 4;              /* media_time (v0) */
+        size_t prefix = n;
+        n += build_cmaf_chunk(obj + n, 1, 0x02000000, 1, 0, 0xAA);
+
+        moq_cmaf_object_report_t rep;
+        CHECK(moq_cmaf_validate_object(NULL, (moq_bytes_t){ obj, n }, &rep)
+              == MOQ_OK);
+        CHECK(rep.valid == true);
+        CHECK(rep.chunk_count == 1);
+        CHECK(rep.starts_with_sync == true);
+
+        moq_cmaf_sample_t s[4];
+        moq_cmaf_fragment_info_t frag;
+        moq_cmaf_fragment_info_init(&frag, s, 4);
+        CHECK(moq_cmaf_parse_fragment((moq_bytes_t){ obj, n }, &frag)
+              == MOQ_OK);
+        CHECK(frag.chunk_count == 1);
+        CHECK(frag.track_id == 1);
+        CHECK(frag.sample_count == 1);
+
+        /* emsg between two chunks of a multi-chunk object also skips. */
+        uint8_t multi[512]; size_t m = 0;
+        m += build_cmaf_chunk(multi + m, 1, 0x02000000, 1, 0, 0xAA);
+        m += box_hdr(multi + m, 12, "emsg");
+        wr32(multi + m, 0x01000000); m += 4;   /* version 1, flags 0 */
+        m += build_cmaf_chunk(multi + m, 1, 0x00000000, 1, 0, 0xBB);
+        CHECK(moq_cmaf_validate_object(NULL, (moq_bytes_t){ multi, m }, &rep)
+              == MOQ_OK);
+        CHECK(rep.chunk_count == 2);
+        moq_cmaf_fragment_info_init(&frag, s, 4);
+        CHECK(moq_cmaf_parse_fragment((moq_bytes_t){ multi, m }, &frag)
+              == MOQ_OK);
+        CHECK(frag.chunk_count == 2);
+
+        /* An unknown top-level box is still not a chunk: reject. */
+        uint8_t bad[256]; size_t bn = 0;
+        bn += box_hdr(bad + bn, 12, "free");
+        wr32(bad + bn, 0); bn += 4;
+        bn += build_cmaf_chunk(bad + bn, 1, 0x02000000, 1, 0, 0xAA);
+        CHECK(moq_cmaf_validate_object(NULL, (moq_bytes_t){ bad, bn }, &rep)
+              == MOQ_ERR_PROTO);
+        CHECK(rep.reason == MOQ_CMAF_ERR_MALFORMED);
+        moq_cmaf_fragment_info_init(&frag, s, 4);
+        CHECK(moq_cmaf_parse_fragment((moq_bytes_t){ bad, bn }, &frag)
+              == MOQ_ERR_PROTO);
+
+        (void)prefix;
+    }
+
     printf("%s: %d failures\n", failures ? "FAIL" : "PASS", failures);
     return failures ? 1 : 0;
 }


### PR DESCRIPTION
## Problem

`moq_cmaf_parse_fragment` and `moq_cmaf_validate_object` require a chunk to start with a `moof` as the very first top-level box and reject the whole object otherwise. ISO/IEC 23000-19 (CMAF) permits `prft` and `emsg` boxes in chunks ahead of the `moof` (and a fragment may lead with `styp`/`sidx`), and real publishers emit them:

- ffmpeg with `-write_prft wallclock` (the standard producer-reference-time latency anchor)
- moqtail's public draft-16 test stream, which prefixes **every** chunk with a `prft`

Every media object from such a publisher is dropped as `MOQ_MEDIA_DROP_MALFORMED_CMAF` at the media layer. The failure is easy to miss operationally: it surfaces only as a growing `parse_drops` stat while the app sees nothing but end-of-group status markers — a subscriber shows "receiving" with permanently black video.

## Repro

```
moq_example_media_receive https://relay.moqtail.dev moqtail/testsrc --insecure-skip-verify
```

Before this change: `CATALOG_READY` fires, then only zero-byte status objects surface; `moq_media_receiver_get_stats` shows `parse_drops` climbing (~500 in 40 s) while `objects_received` counts only markers. The dropped payloads start `00 00 00 20 'prft' …` followed by a well-formed `moof`+`mdat`.

After: media objects parse and deliver normally (verified end-to-end against the moqtail stream, and against a plain ffmpeg CMAF publisher for no-regression).

## Change

Skip `prft`/`emsg`/`styp`/`sidx` wherever a chunk boundary expects a `moof`, in both `moq_cmaf_parse_fragment` and `moq_cmaf_validate_object`. These are metadata, not chunk structure. Unknown top-level boxes (e.g. `free`) still reject, so the CMSF §3.3 successive moof+mdat rule is preserved for genuine structure violations — covered by a negative test.

Tests: new block 42 in `test_cmaf.c` (prft-prefixed chunk parses + validates, emsg between chunks of a multi-chunk object skips, unknown box still rejects). Full `test_cmaf` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/2)
<!-- Reviewable:end -->
