### PR TITLE
[Feat] Add parametrizable handshake timeout

### DIFF
--- a/service/include/moq/endpoint.h
+++ b/service/include/moq/endpoint.h
@@ -207,6 +207,17 @@ typedef struct moq_endpoint_cfg {
      * set it via moq_endpoint_cfg_init_sized(&cfg, sizeof cfg), not the
      * pointer-only moq_endpoint_cfg_init(). */
     uint32_t wt_profile;
+    /* appended (enabled by struct_size): upper bound in microseconds on the
+     * TRANSPORT handshake -- how long a peer that never completes the QUIC/TLS
+     * handshake holds the endpoint in CONNECTING before it goes terminal. It
+     * does NOT bound a peer that completes the handshake and then stalls the
+     * WebTransport CONNECT or the MoQ SETUP. 0 leaves the backend's own value
+     * (30 s on picoquic). Honored by the picoquic backend on both protocols; no
+     * other backend exposes a handshake bound, so a NON-ZERO value there is a
+     * connect-time MOQ_ERR_UNSUPPORTED, not a silent no-op. Because it is past
+     * the v0 floor, connect() reads it ONLY when struct_size covers it fully --
+     * set it via moq_endpoint_cfg_init_sized(&cfg, sizeof cfg). */
+    uint64_t handshake_timeout_us;
 } moq_endpoint_cfg_t;
 
 /* Frozen v0 config floor: the smallest cfg struct_size connect()/resolve accept.
@@ -223,16 +234,18 @@ typedef struct moq_endpoint_cfg {
  * clears and stamps ONLY the frozen v0 prefix (MOQ_ENDPOINT_CFG_V0_SIZE) and
  * leaves every appended tail field untouched. A config produced this way runs
  * with the tail ABSENT (struct_size stops at the v0 floor), which resolves to
- * MOQ_WT_PROFILE_BACKEND_DEFAULT for wt_profile -- no explicit selection.
- * Because it never writes past the v0 floor, it can NEVER overflow the buffer of
- * an old caller that predates a later tail field. To SET any tail field, use
+ * MOQ_WT_PROFILE_BACKEND_DEFAULT for wt_profile (no explicit selection) and to 0
+ * (the backend default) for handshake_timeout_us. Because it never writes past
+ * the v0 floor, it can NEVER overflow the buffer of an old caller that predates
+ * a later tail field. To SET any tail field, use
  * moq_endpoint_cfg_init_sized(). */
 MOQ_API void moq_endpoint_cfg_init(moq_endpoint_cfg_t *cfg);
 
 /* Sized initializer: clears and stamps min(cfg_size, current sizeof) -- the
- * initializer to use whenever you set anything beyond the v0 floor (wt_profile).
- * Pass sizeof(moq_endpoint_cfg_t). Never writes past cfg_size, so it is safe for
- * a caller compiled against an older, smaller header too. */
+ * initializer to use whenever you set anything beyond the v0 floor (wt_profile,
+ * handshake_timeout_us). Pass sizeof(moq_endpoint_cfg_t). Never writes past
+ * cfg_size, so it is safe for a caller compiled against an older, smaller
+ * header too. */
 MOQ_API void moq_endpoint_cfg_init_sized(moq_endpoint_cfg_t *cfg,
                                          size_t cfg_size);
 

--- a/service/src/endpoint.c
+++ b/service/src/endpoint.c
@@ -318,6 +318,21 @@ moq_result_t moq_endpoint_resolve_cfg(const moq_endpoint_cfg_t *cfg,
         out->wt_profile = cfg->wt_profile;
     }
 
+    /* Handshake bound: the same complete-presence gate; a v0-sized caller gets
+     * 0 (already memset) = the backend's own default. Only picoquic can apply
+     * it (the connect path's configure_quic hook); every other backend would
+     * silently ignore it, so a non-zero value there is an UNSUPPORTED reject,
+     * as with wt_profile. */
+    out->handshake_timeout_us = 0;
+    if ((size_t)cfg->struct_size >=
+        offsetof(moq_endpoint_cfg_t, handshake_timeout_us) +
+            sizeof(cfg->handshake_timeout_us)) {
+        if (cfg->handshake_timeout_us != 0 &&
+            out->backend != MOQ_TRANSPORT_BACKEND_PICOQUIC)
+            return MOQ_ERR_UNSUPPORTED;
+        out->handshake_timeout_us = cfg->handshake_timeout_us;
+    }
+
     return resolve_versions(&cfg->versions, out);
 }
 
@@ -379,6 +394,7 @@ struct moq_endpoint {
     char *path;    size_t path_len;    /* WT path; NULL for RAW_QUIC */
     char *ca_file; size_t ca_file_len; /* NULL = system roots */
     bool  insecure;
+    uint64_t handshake_timeout_us;     /* 0 = backend default; picoquic only */
 
     /* The version offer as transport tokens, preference order. The ALPN
      * entries point at the static strings in moq_alpn.h (no ownership);
@@ -674,13 +690,16 @@ static int ep_wtquic_msquic_pump(moq_wtquic_msquic_managed_t *m,
 #endif
 
 #if defined(MOQ_SERVICE_HAVE_PQ_THREADED) || defined(MOQ_SERVICE_HAVE_PICO_WT_MANAGED)
-/* Install real certificate verification unless explicitly skipped: chain +
- * server-name validation against ep->ca_file (NULL = system roots). The
- * facades' built-in default accepts the peer cert, which is NOT
- * production-safe -- making the safe path the default is this tier's job. */
+/* Apply the caller's handshake bound, then install real certificate
+ * verification unless explicitly skipped: chain + server-name validation
+ * against ep->ca_file (NULL = system roots). The facades' built-in default
+ * accepts the peer cert, which is NOT production-safe -- making the safe path
+ * the default is this tier's job.  */
 static int ep_configure_quic(picoquic_quic_t *quic, void *ctx)
 {
     moq_endpoint_t *ep = (moq_endpoint_t *)ctx;
+    if (ep->handshake_timeout_us > 0)
+        picoquic_set_default_handshake_timeout(quic, ep->handshake_timeout_us);
     if (ep->insecure) return 0;
     return moq_picoquic_set_cert_verifier(quic, ep->ca_file);
 }
@@ -1607,6 +1626,7 @@ moq_result_t moq_endpoint_connect(const moq_endpoint_cfg_t *cfg,
     ep->alloc = *alloc;
     ep->protocol = r.protocol;
     ep->insecure = cfg->insecure_skip_verify;
+    ep->handshake_timeout_us = r.handshake_timeout_us;
     atomic_init(&ep->interrupted, false);
     atomic_init(&ep->closed, false);
     pthread_mutex_init(&ep->mu, NULL);

--- a/service/src/endpoint_internal.h
+++ b/service/src/endpoint_internal.h
@@ -33,6 +33,11 @@ typedef struct moq_endpoint_resolved {
      * predates the field. Consumed only by WebTransport backends that honor a
      * dialect choice (wtquic-msquic). */
     uint32_t      wt_profile;
+    /* Transport-handshake bound in microseconds, struct_size-gated at resolve;
+     * 0 (the backend default) when the cfg predates the field. Consumed only by
+     * the picoquic backends -- resolve rejects a non-zero value on any backend
+     * that cannot apply it. */
+    uint64_t      handshake_timeout_us;
 } moq_endpoint_resolved_t;
 
 /*

--- a/service/tests/test_endpoint_resolve.c
+++ b/service/tests/test_endpoint_resolve.c
@@ -55,6 +55,8 @@ int main(void)
         MOQ_TEST_CHECK_EQ_INT((int)s.perspective, (int)MOQ_PERSPECTIVE_CLIENT);
         MOQ_TEST_CHECK_EQ_U64(s.wt_profile,
                               (uint64_t)MOQ_WT_PROFILE_BACKEND_DEFAULT);
+        /* Same for the handshake bound: 0 = the backend's own default. */
+        MOQ_TEST_CHECK_EQ_U64(s.handshake_timeout_us, 0);
         /* The v0 floor must sit exactly at wt_profile (the first tail field). */
         MOQ_TEST_CHECK_EQ_U64(MOQ_ENDPOINT_CFG_V0_SIZE,
                               offsetof(moq_endpoint_cfg_t, wt_profile));
@@ -129,6 +131,58 @@ int main(void)
 #endif
     }
 
+    /* == handshake_timeout_us resolve: gate + backend rejection ======= *
+     * The bound is applied on the QUIC context by the picoquic backend (the
+     * AUTO one, always compiled in) and by no other; 0 means "the backend's own
+     * default" and is accepted everywhere. */
+    {
+        moq_endpoint_resolved_t r;
+
+        /* v0-sized caller (no field): 0, and resolve never reads past it. */
+        moq_endpoint_cfg_t v0 = mkcfg("moqt://relay.example:4433");
+        v0.struct_size = MOQ_ENDPOINT_CFG_V0_SIZE;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&v0, &r), (int)MOQ_OK);
+        MOQ_TEST_CHECK_EQ_U64(r.handshake_timeout_us, 0);
+
+        /* Full-size caller on picoquic: carried through verbatim. */
+        moq_endpoint_cfg_t c;
+        moq_endpoint_cfg_init_sized(&c, sizeof(c));
+        c.url = B("moqt://relay.example:4433");
+        c.handshake_timeout_us = 5000000ull;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&c, &r), (int)MOQ_OK);
+        MOQ_TEST_CHECK_EQ_U64(r.handshake_timeout_us, 5000000ull);
+
+        /* Explicit 0 stays 0 (backend default), not a smuggled value. */
+        c.handshake_timeout_us = 0;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&c, &r), (int)MOQ_OK);
+        MOQ_TEST_CHECK_EQ_U64(r.handshake_timeout_us, 0);
+
+        /* A struct_size that only PARTIALLY covers the field must not read it
+         * (complete-presence gate): treated as absent -> backend default. */
+        moq_endpoint_cfg_t part;
+        moq_endpoint_cfg_init_sized(&part, sizeof(part));
+        part.url = B("moqt://relay.example:4433");
+        part.handshake_timeout_us = 5000000ull;
+        part.struct_size = (uint32_t)(
+            offsetof(moq_endpoint_cfg_t, handshake_timeout_us) + 1);
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&part, &r), (int)MOQ_OK);
+        MOQ_TEST_CHECK_EQ_U64(r.handshake_timeout_us, 0);
+
+#ifdef MOQ_SERVICE_HAVE_MSQUIC_MANAGED
+        /* A backend with no handshake bound REJECTS a non-zero value rather
+         * than silently ignoring it; zero is still fine there. */
+        moq_endpoint_cfg_t m;
+        moq_endpoint_cfg_init_sized(&m, sizeof(m));
+        m.url = B("moqt://relay.example:4433");
+        m.backend = MOQ_TRANSPORT_BACKEND_MSQUIC;
+        m.handshake_timeout_us = 5000000ull;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&m, &r),
+                              (int)MOQ_ERR_UNSUPPORTED);
+        m.handshake_timeout_us = 0;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_resolve_cfg(&m, &r), (int)MOQ_OK);
+#endif
+    }
+
     /* == old-caller overflow guard (v0-sized HEAP buffer) ============= *
      * Simulate a binary compiled against the pre-wt_profile header: a heap
      * allocation of exactly the v0 size. The pointer-only init must not write
@@ -148,6 +202,7 @@ int main(void)
                                   (int)MOQ_OK);
             MOQ_TEST_CHECK_EQ_U64(r.wt_profile,
                                   (uint64_t)MOQ_WT_PROFILE_BACKEND_DEFAULT);
+            MOQ_TEST_CHECK_EQ_U64(r.handshake_timeout_us, 0);
             free(raw);
         }
     }


### PR DESCRIPTION
### Description

With no reachable server, connect sits in `CONNECTING` for **30 s** before going terminal — picoquic's `PICOQUIC_MICROSEC_HANDSHAKE_MAX` default, which no service-tier caller could shorten (`moq_endpoint_cfg_t` had no timeout field).

Adds an appended, `struct_size`-gated field, following the `wt_profile` pattern:

```c
uint64_t handshake_timeout_us;   /* 0 = backend default */
```

`resolve` gates it, and `ep_configure_quic()` applies it with
`picoquic_set_default_handshake_timeout()` on the QUIC context before any connection
exists — so it covers both picoquic facades (raw QUIC and pico_wt).

**Contract**
- `0` = backend default → no behavior change for existing callers.
- Non-zero on a backend that cannot apply it (msquic, mvfst, proxygen, wtquic-*) is a
  resolve-time `MOQ_ERR_UNSUPPORTED`, not a silent no-op — same rule as `wt_profile`.
- Bounds the **transport handshake only**: a peer that completes the QUIC handshake and
  then stalls the WT CONNECT or the MoQ SETUP is not covered.

**Tests** — new `test_endpoint_resolve` cases (v0 caller, full size, explicit 0, partial
`struct_size`, non-picoquic reject). `endpoint_resolve`, `endpoint_post_contract` and
`endpoint_lifecycle` pass.

**Measured** — client against `127.0.0.1:4433` with nothing listening, through
`moq_media_sender_create()` + `on_closed`: `0` → 30.02 s, `5000000` → 5.03 s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/6)
<!-- Reviewable:end -->
