### PR TITLE
Feat: add a cmaf packager library

### DIFF
--- a/bindings/cpp/tests/test_cmaf.cpp
+++ b/bindings/cpp/tests/test_cmaf.cpp
@@ -107,7 +107,7 @@ static size_t build_aac_init(uint8_t *buf, uint32_t timescale,
     wr32(buf + p, 1); p += 4;
     p += box_hdr(buf + p, (uint32_t)mp4a_sz, "mp4a");
     std::memset(buf + p, 0, 28);
-    wr16(buf + p + 8, channels);
+    wr16(buf + p + 16, channels);  /* channelcount */
     wr16(buf + p + 24, samplerate);
     p += 28;
     p += box_hdr(buf + p, (uint32_t)esds_sz, "esds");

--- a/bindings/swift/Tests/MoQMediaTests/CMAFParserTests.swift
+++ b/bindings/swift/Tests/MoQMediaTests/CMAFParserTests.swift
@@ -118,8 +118,8 @@ private func buildAACInit(
     // mp4a
     boxHdr(&buf, UInt32(mp4aSize), "mp4a")
     var mp4aFixed = Data(repeating: 0, count: 28)
-    mp4aFixed[8] = UInt8(channels >> 8)
-    mp4aFixed[9] = UInt8(channels & 0xFF)
+    mp4aFixed[16] = UInt8(channels >> 8)
+    mp4aFixed[17] = UInt8(channels & 0xFF)
     mp4aFixed[24] = UInt8(samplerate >> 8)
     mp4aFixed[25] = UInt8(samplerate & 0xFF)
     buf.append(mp4aFixed)

--- a/bindings/swift/Tests/MoQMediaTests/PlaybackTrackDescriptorTests.swift
+++ b/bindings/swift/Tests/MoQMediaTests/PlaybackTrackDescriptorTests.swift
@@ -61,7 +61,7 @@ private func buildAACInit(
     hdr(UInt32(stsdSize), "stsd"); w32(0); w32(1)
     hdr(UInt32(mp4aSize), "mp4a")
     var mp4aFixed = Data(repeating: 0, count: 28)
-    mp4aFixed[8] = UInt8(channels >> 8); mp4aFixed[9] = UInt8(channels & 0xFF)
+    mp4aFixed[16] = UInt8(channels >> 8); mp4aFixed[17] = UInt8(channels & 0xFF) // channelcount
     mp4aFixed[24] = UInt8(samplerate >> 8); mp4aFixed[25] = UInt8(samplerate & 0xFF)
     buf.append(mp4aFixed)
     hdr(UInt32(esdsSize), "esds"); w32(0)

--- a/media/cmaf/src/cmaf.c
+++ b/media/cmaf/src/cmaf.c
@@ -368,7 +368,7 @@ static moq_result_t parse_stsd_entry(const uint8_t *stsd_box,
         eb = body + entry.hdr + 28;
         eb_len = entry.size - entry.hdr - 28;
         out->samplerate = rd16(body + entry.hdr + 24);
-        out->channel_count = rd16(body + entry.hdr + 8);
+        out->channel_count = rd16(body + entry.hdr + 16);
     } else {
         out->codec_kind = MOQ_CMAF_CODEC_UNKNOWN;
         return MOQ_OK;

--- a/media/cmaf/tests/test_cmaf.c
+++ b/media/cmaf/tests/test_cmaf.c
@@ -172,7 +172,7 @@ static size_t build_aac_init(uint8_t *buf, size_t cap,
     /* mp4a */
     p += box_hdr(buf + p, (uint32_t)mp4a_size, "mp4a");
     memset(buf + p, 0, 28);
-    wr16(buf + p + 8, channels);
+    wr16(buf + p + 16, channels);
     wr16(buf + p + 24, samplerate);
     p += 28;
 
@@ -933,7 +933,7 @@ int main(void)
         wr32(buf + p, 1); p += 4;
         p += box_hdr(buf + p, (uint32_t)mp4a_size, "mp4a");
         memset(buf + p, 0, 28);
-        wr16(buf + p + 8, 2);
+        wr16(buf + p + 16, 2);
         wr16(buf + p + 24, 48000);
         p += 28;
         p += box_hdr(buf + p, (uint32_t)esds_size, "esds");

--- a/media/msf/tests/test_msf_media.c
+++ b/media/msf/tests/test_msf_media.c
@@ -139,7 +139,7 @@ static size_t build_aac_init(uint8_t *buf, uint32_t timescale,
     wr32(buf + p, 1); p += 4;
     p += box_hdr(buf + p, (uint32_t)mp4a_size, "mp4a");
     memset(buf + p, 0, 28);
-    wr16(buf + p + 8, channels);
+    wr16(buf + p + 16, channels);  /* channelcount */
     wr16(buf + p + 24, samplerate);
     p += 28;
     p += box_hdr(buf + p, (uint32_t)esds_size, "esds");

--- a/media/playback/tests/test_playback_api.c
+++ b/media/playback/tests/test_playback_api.c
@@ -262,7 +262,7 @@ static size_t build_aac_init(uint8_t *buf, uint32_t timescale,
     wr32(buf + p, 1); p += 4;
     p += box_hdr(buf + p, (uint32_t)mp4a_size, "mp4a");
     memset(buf + p, 0, 28);
-    wr16(buf + p + 8, channels);
+    wr16(buf + p + 16, channels);  /* AudioSampleEntry channelcount */
     wr16(buf + p + 24, samplerate);
     p += 28;
     p += box_hdr(buf + p, (uint32_t)esds_size, "esds");

--- a/media/playback/tests/test_playback_oom.c
+++ b/media/playback/tests/test_playback_oom.c
@@ -180,7 +180,7 @@ static size_t build_aac_init(uint8_t *buf, uint32_t timescale,
     wr32(buf+p,0); p+=4; wr32(buf+p,1); p+=4;
     p+=box_hdr(buf+p,(uint32_t)mp,"mp4a");
     memset(buf+p,0,28);
-    wr16(buf+p+8,channels); wr16(buf+p+24,samplerate); p+=28;
+    wr16(buf+p+16,channels); wr16(buf+p+24,samplerate); p+=28;
     p+=box_hdr(buf+p,(uint32_t)esz,"esds");
     wr32(buf+p,0); p+=4;
     buf[p++]=0x03; buf[p++]=(uint8_t)(esl-2);


### PR DESCRIPTION
New `media/cmaf_packager` library: builds CMAF init segments and chunks from
encoded samples. The write side of `media/cmaf`.

Supports AVC, HEVC, AV1, AAC and Opus.

Also fixes AudioSampleEntry channelcount in `media/cmaf` (offset 16, not 8),
which the packager's audio tests depend on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/7)
<!-- Reviewable:end -->
