### PR TITLE
fix: encode LOC object properties for the negotiated draft

### DIFF
--- a/bindings/cpp/include/moq/loc.hpp
+++ b/bindings/cpp/include/moq/loc.hpp
@@ -46,11 +46,14 @@ struct headers {
     bytes_view video_config{};
 };
 
-inline result<headers> parse(profile p, bytes_view properties)
+/* `draft` is the version the session negotiated: it selects the property
+ * block's integer encoding (see moq/loc.h). */
+inline result<headers> parse(profile p, moq_version_t draft,
+                             bytes_view properties)
 {
     moq_loc_headers_t ch;
     moq_result_t rc = moq_loc_parse(
-        static_cast<moq_loc_profile_t>(p), properties.raw(), &ch);
+        static_cast<moq_loc_profile_t>(p), draft, properties.raw(), &ch);
     if (rc < 0)
         return errc_from_result(rc);
 
@@ -84,7 +87,7 @@ inline result<headers> parse(profile p, bytes_view properties)
     return h;
 }
 
-inline result<buffer> encode(profile p, const headers &h,
+inline result<buffer> encode(profile p, moq_version_t draft, const headers &h,
                               const moq_alloc_t *alloc = moq_alloc_default())
 {
     moq_loc_headers_t ch;
@@ -120,7 +123,7 @@ inline result<buffer> encode(profile p, const headers &h,
 
     moq_rcbuf_t *raw = nullptr;
     moq_result_t rc = moq_loc_encode(alloc,
-        static_cast<moq_loc_profile_t>(p), &ch, &raw);
+        static_cast<moq_loc_profile_t>(p), draft, &ch, &raw);
     if (rc < 0)
         return errc_from_result(rc);
 

--- a/bindings/cpp/tests/consumer/main.cpp
+++ b/bindings/cpp/tests/consumer/main.cpp
@@ -206,12 +206,13 @@ int main()
         moq::loc::headers lh;
         lh.has_timestamp = true;
         lh.timestamp     = 42;
-        auto enc = moq::loc::encode(moq::loc::profile::loc01, lh);
+        auto enc = moq::loc::encode(moq::loc::profile::loc01,
+            MOQ_VERSION_DRAFT_16, lh);
         CHECK(enc.ok(), 40);
         CHECK(!enc->empty(), 41);
 
         auto dec = moq::loc::parse(moq::loc::profile::loc01,
-            moq::bytes_view(enc->data(), enc->size()));
+            MOQ_VERSION_DRAFT_16, moq::bytes_view(enc->data(), enc->size()));
         CHECK(dec.ok(), 42);
         CHECK(dec->timestamp == 42, 43);
     }

--- a/bindings/cpp/tests/test_loc.cpp
+++ b/bindings/cpp/tests/test_loc.cpp
@@ -9,7 +9,8 @@ int main()
 
     // Parse empty LOC-01 — success, no fields
     {
-        auto r = moq::loc::parse(moq::loc::profile::loc01, {});
+        auto r = moq::loc::parse(moq::loc::profile::loc01,
+                                 MOQ_VERSION_DRAFT_16, {});
         MOQ_CHECK(r.ok());
         MOQ_CHECK(!r->has_timestamp);
         MOQ_CHECK(!r->has_timescale);
@@ -21,7 +22,8 @@ int main()
     // Encode empty LOC-01 — success, empty/default buffer
     {
         moq::loc::headers h;
-        auto r = moq::loc::encode(moq::loc::profile::loc01, h);
+        auto r = moq::loc::encode(moq::loc::profile::loc01,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(r.ok());
         MOQ_CHECK(r->empty());
     }
@@ -32,7 +34,8 @@ int main()
         h.has_timestamp = true;
         h.timestamp     = 1000000;
 
-        auto r = moq::loc::encode(moq::loc::profile::loc01, h);
+        auto r = moq::loc::encode(moq::loc::profile::loc01,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(r.ok());
         MOQ_CHECK(r->size() == 5);
         auto d = r->data();
@@ -50,7 +53,8 @@ int main()
         h.audio_level.voice_activity = true;
         h.audio_level.level          = 30;
 
-        auto r = moq::loc::encode(moq::loc::profile::loc01, h);
+        auto r = moq::loc::encode(moq::loc::profile::loc01,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(r.ok());
         MOQ_CHECK(r->size() == 3);
         auto d = r->data();
@@ -63,7 +67,7 @@ int main()
     {
         // Build wire: delta=0x0d, length=3, data={0xAA,0xBB,0xCC}
         uint8_t wire[] = {0x0d, 0x03, 0xAA, 0xBB, 0xCC};
-        auto r = moq::loc::parse(moq::loc::profile::loc01,
+        auto r = moq::loc::parse(moq::loc::profile::loc01, MOQ_VERSION_DRAFT_16,
                                   moq::bytes_view(wire, sizeof(wire)));
         MOQ_CHECK(r.ok());
         MOQ_CHECK(r->has_video_config);
@@ -75,7 +79,8 @@ int main()
 
     // LOC-02 parse returns errc::invalid
     {
-        auto r = moq::loc::parse(moq::loc::profile::loc02, {});
+        auto r = moq::loc::parse(moq::loc::profile::loc02,
+                                 MOQ_VERSION_DRAFT_16, {});
         MOQ_CHECK(!r.ok());
         MOQ_CHECK(r.error().code() == moq::errc::invalid);
     }
@@ -85,7 +90,8 @@ int main()
         moq::loc::headers h;
         h.has_timestamp = true;
         h.timestamp     = 48000;
-        auto r = moq::loc::encode(moq::loc::profile::loc02, h);
+        auto r = moq::loc::encode(moq::loc::profile::loc02,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(!r.ok());
         MOQ_CHECK(r.error().code() == moq::errc::invalid);
     }
@@ -94,7 +100,7 @@ int main()
     {
         // delta=6, value=0x100 (2-byte QUIC varint: 0x41 0x00)
         uint8_t wire[] = {0x06, 0x41, 0x00};
-        auto r = moq::loc::parse(moq::loc::profile::loc01,
+        auto r = moq::loc::parse(moq::loc::profile::loc01, MOQ_VERSION_DRAFT_16,
                                   moq::bytes_view(wire, sizeof(wire)));
         MOQ_CHECK(!r.ok());
         MOQ_CHECK(r.error().code() == moq::errc::protocol);
@@ -104,7 +110,7 @@ int main()
     {
         // delta=4, value=0x10000 (4-byte QUIC varint: 0x80 0x01 0x00 0x00)
         uint8_t wire[] = {0x04, 0x80, 0x01, 0x00, 0x00};
-        auto r = moq::loc::parse(moq::loc::profile::loc01,
+        auto r = moq::loc::parse(moq::loc::profile::loc01, MOQ_VERSION_DRAFT_16,
                                   moq::bytes_view(wire, sizeof(wire)));
         MOQ_CHECK(!r.ok());
         MOQ_CHECK(r.error().code() == moq::errc::protocol);
@@ -118,12 +124,13 @@ int main()
         h.has_video_config = true;
         h.video_config     = moq::bytes_view(cfg_data, sizeof(cfg_data));
 
-        auto enc = moq::loc::encode(moq::loc::profile::loc01, h);
+        auto enc = moq::loc::encode(moq::loc::profile::loc01,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(enc.ok());
         MOQ_CHECK(!enc->empty());
 
         auto dec = moq::loc::parse(moq::loc::profile::loc01,
-            moq::bytes_view(enc->data(), enc->size()));
+            MOQ_VERSION_DRAFT_16, moq::bytes_view(enc->data(), enc->size()));
         MOQ_CHECK(dec.ok());
         MOQ_CHECK(dec->has_video_config);
         MOQ_CHECK(dec->video_config.size() == sizeof(cfg_data));
@@ -148,11 +155,12 @@ int main()
         h.has_video_config                          = true;
         h.video_config = moq::bytes_view(cfg, sizeof(cfg));
 
-        auto enc = moq::loc::encode(moq::loc::profile::loc01, h);
+        auto enc = moq::loc::encode(moq::loc::profile::loc01,
+                                  MOQ_VERSION_DRAFT_16, h);
         MOQ_CHECK(enc.ok());
 
         auto dec = moq::loc::parse(moq::loc::profile::loc01,
-            moq::bytes_view(enc->data(), enc->size()));
+            MOQ_VERSION_DRAFT_16, moq::bytes_view(enc->data(), enc->size()));
         MOQ_CHECK(dec.ok());
         MOQ_CHECK(dec->timestamp == 5000);
         MOQ_CHECK(dec->video_frame_marking.independent);

--- a/bindings/swift/Tests/MoQMediaTests/MediaObjectParserTests.swift
+++ b/bindings/swift/Tests/MoQMediaTests/MediaObjectParserTests.swift
@@ -25,7 +25,8 @@ private func encodeLOCProperties(
     }
     var props: OpaquePointer?
     let alloc = moq_alloc_default()!
-    let rc = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &headers, &props)
+    let rc = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                            &headers, &props)
     guard rc == MOQ_OK else { throw MoQError.internal }
     guard let p = props else { return nil }
     return Buffer(adopting: p)

--- a/bindings/swift/Tests/MoQMediaTests/PlaybackPipelineTests.swift
+++ b/bindings/swift/Tests/MoQMediaTests/PlaybackPipelineTests.swift
@@ -22,7 +22,8 @@ private func encodeLOCProps(
         h.video_frame_marking.end_of_frame = true
     }
     var p: OpaquePointer?
-    let rc = moq_loc_encode(moq_alloc_default()!, MOQ_LOC_PROFILE_01, &h, &p)
+    let rc = moq_loc_encode(moq_alloc_default()!, MOQ_LOC_PROFILE_01,
+                            MOQ_VERSION_DRAFT_16, &h, &p)
     guard rc == MOQ_OK else { throw MoQError.internal }
     guard let ptr = p else { return nil }
     return Buffer(adopting: ptr)

--- a/bindings/swift/Tests/MoQMediaTests/TrackRouterTests.swift
+++ b/bindings/swift/Tests/MoQMediaTests/TrackRouterTests.swift
@@ -19,7 +19,8 @@ private func encodeLOCProps(
         h.video_frame_marking.end_of_frame = true
     }
     var p: OpaquePointer?
-    let rc = moq_loc_encode(moq_alloc_default()!, MOQ_LOC_PROFILE_01, &h, &p)
+    let rc = moq_loc_encode(moq_alloc_default()!, MOQ_LOC_PROFILE_01,
+                            MOQ_VERSION_DRAFT_16, &h, &p)
     guard rc == MOQ_OK else { throw MoQError.internal }
     guard let ptr = p else { return nil }
     return Buffer(adopting: ptr)

--- a/examples/local-media/publisher/main.c
+++ b/examples/local-media/publisher/main.c
@@ -368,8 +368,10 @@ static int loop_callback(picoquic_quic_t *quic,
         lh.video_frame_marking.independent = is_key;
 
         moq_rcbuf_t *props = NULL;
-        if (moq_loc_encode(&ctx->alloc, MOQ_LOC_PROFILE_01, &lh,
-                            &props) != MOQ_OK) {
+        /* The property block follows the session's draft; this demo leaves the
+         * session at the default draft-16. */
+        if (moq_loc_encode(&ctx->alloc, MOQ_LOC_PROFILE_01,
+                            MOQ_VERSION_DRAFT_16, &lh, &props) != MOQ_OK) {
             running = 0;
             return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
         }

--- a/media/loc/include/moq/loc.h
+++ b/media/loc/include/moq/loc.h
@@ -8,6 +8,11 @@
  * bytes for the selected LOC profile. Each profile maps typed C
  * fields to the property IDs defined by that LOC draft version.
  *
+ * The LOC profile fixes the property IDs and their semantics; the
+ * negotiated MoQ transport draft fixes how the property block encodes
+ * integers, so both parse and encode take it (see the `draft`
+ * parameter below).
+ *
  * Pure helper library: no sessions, no I/O, no threads.
  * Link against moq::loc (depends only on moq::core).
  *
@@ -16,6 +21,7 @@
 
 #include <moq/types.h>
 #include <moq/rcbuf.h>
+#include <moq/session.h>   /* moq_version_t: the negotiated transport draft */
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,8 +31,19 @@ extern "C" {
 
 typedef enum moq_loc_profile {
     MOQ_LOC_PROFILE_01 = 1,  /* draft-ietf-moq-loc-01 */
-    MOQ_LOC_PROFILE_02 = 2,  /* draft-ietf-moq-loc-02; reserved, requires D18 KVP codec */
+    MOQ_LOC_PROFILE_02 = 2,  /* draft-ietf-moq-loc-02; reserved, its property
+                              * mapping is not implemented (ID 0x06 collides
+                              * with LOC-01 Audio Level) */
 } moq_loc_profile_t;
+
+/* -- Property block encoding ------------------------------------------ *
+ * A property block is a list of typed properties whose integer encoding is
+ * fixed by the negotiated MoQ draft (draft-ietf-moq-transport-18 §1.4.1 and
+ * §1.4.3, draft-16 §1.4.2). Draft-16 and draft-18 encode integers differently
+ * and agree only for values up to 63, so a block written for one draft is
+ * rejected on a session that negotiated the other. Callers pass the version
+ * the session negotiated (moq_endpoint_negotiated_version); MOQ_ERR_INVAL for
+ * any other value. */
 
 /* -- Video Frame Marking (RFC 9626 §3.1) ------------------------------ */
 
@@ -88,10 +105,11 @@ MOQ_API void moq_loc_headers_init(moq_loc_headers_t *h);
  *
  * Returns MOQ_OK on success.
  * Returns MOQ_ERR_INVAL if out is NULL, data is NULL with len > 0,
- *   or profile is not a supported value.
+ *   or profile / draft is not a supported value.
  * Returns MOQ_ERR_PROTO on malformed data.
  */
 MOQ_API moq_result_t moq_loc_parse(moq_loc_profile_t profile,
+                                    moq_version_t draft,
                                     moq_bytes_t properties,
                                     moq_loc_headers_t *out);
 
@@ -104,11 +122,13 @@ MOQ_API moq_result_t moq_loc_parse(moq_loc_profile_t profile,
  * If no fields are set, returns MOQ_OK with *out_properties = NULL.
  * Returns MOQ_ERR_INVAL on invalid input (audio level > 127,
  *   temporal_id > 7, NULL alloc or out_properties, unsupported
- *   profile, or a field unsupported by the selected profile).
+ *   profile or draft, a field unsupported by the selected profile, or
+ *   a value the draft's integer encoding cannot represent).
  * Returns MOQ_ERR_NOMEM on allocation failure.
  */
 MOQ_API moq_result_t moq_loc_encode(const moq_alloc_t *alloc,
                                      moq_loc_profile_t profile,
+                                     moq_version_t draft,
                                      const moq_loc_headers_t *headers,
                                      moq_rcbuf_t **out_properties);
 

--- a/media/loc/src/loc.c
+++ b/media/loc/src/loc.c
@@ -1,13 +1,42 @@
 #include <moq/loc.h>
-#include <moq/kvp.h>
+#include <moq/vi64.h>
 #include <moq/wire.h>
 #include <string.h>
 
 /*
- * LOC-02 uses transport-17/18 vi64 integer encoding and a different
- * KVP wire format. Until a vi64 codec lands in moq-core, LOC-02
- * parse/encode returns MOQ_ERR_INVAL.
+ * LOC-02 reassigns the property IDs (Timestamp moves to 0x06, which LOC-01
+ * uses for Audio Level) and adds a timescale. That mapping is not
+ * implemented: LOC-02 parse/encode returns MOQ_ERR_INVAL.
  */
+
+/* -- KVP integer codec (per negotiated draft) ------------------------- *
+ * The KVP layout is the same in both drafts; only the variable-length integer
+ * differs, so one set of walkers is parameterized by the codec. */
+
+typedef struct loc_vint {
+    size_t (*len)(uint64_t value);
+    size_t (*encode)(uint64_t value, uint8_t *buf, size_t buf_len);
+    size_t (*decode)(const uint8_t *buf, size_t buf_len, uint64_t *out_value);
+} loc_vint_t;
+
+static const loc_vint_t loc_vint_quic = {
+    moq_quic_varint_len, moq_quic_varint_encode, moq_quic_varint_decode,
+};
+
+static const loc_vint_t loc_vint_vi64 = {
+    moq_vi64_len, moq_vi64_encode, moq_vi64_decode,
+};
+
+/* The integer codec the negotiated draft uses for property KVPs
+ * (draft-ietf-moq-transport-18 §1.4.1), or NULL for an unknown version. */
+static const loc_vint_t *loc_vint_for(moq_version_t draft)
+{
+    switch (draft) {
+    case MOQ_VERSION_DRAFT_16: return &loc_vint_quic;
+    case MOQ_VERSION_DRAFT_18: return &loc_vint_vi64;
+    }
+    return NULL;
+}
 
 /* -- Property IDs (LOC-01, draft-ietf-moq-loc-01) -------------------- */
 
@@ -83,6 +112,7 @@ static uint64_t encode_audio_level(const moq_loc_audio_level_t *al)
 /* -- Parse ----------------------------------------------------------- */
 
 moq_result_t moq_loc_parse(moq_loc_profile_t profile,
+                            moq_version_t draft,
                             moq_bytes_t properties,
                             moq_loc_headers_t *out)
 {
@@ -92,24 +122,36 @@ moq_result_t moq_loc_parse(moq_loc_profile_t profile,
     if (profile != MOQ_LOC_PROFILE_01)
         return MOQ_ERR_INVAL;
 
+    const loc_vint_t *vi = loc_vint_for(draft);
+    if (!vi)
+        return MOQ_ERR_INVAL;
+
     if (properties.len == 0)
         return MOQ_OK;
     if (!properties.data)
         return MOQ_ERR_INVAL;
 
-    moq_kvp_decoder_t dec;
-    moq_kvp_decoder_init(&dec, properties.data, properties.len);
+    const uint8_t *p = properties.data;
+    size_t rem = properties.len;
+    uint64_t prev = 0;
 
-    moq_kvp_entry_t entry;
-    moq_result_t rc;
-    while ((rc = moq_kvp_decode_next(&dec, &entry)) == MOQ_OK) {
-        if (entry.is_varint) {
+    while (rem > 0) {
+        uint64_t delta = 0;
+        size_t n = vi->decode(p, rem, &delta);
+        if (n == 0) return MOQ_ERR_PROTO;
+        p += n; rem -= n;
+
+        if (delta > UINT64_MAX - prev) return MOQ_ERR_PROTO;
+        uint64_t type = prev + delta;
+        prev = type;
+
+        if ((type & 1u) == 0) {          /* even type: one integer value */
             uint64_t val = 0;
-            if (moq_quic_varint_decode(entry.value, entry.value_len, &val)
-                != entry.value_len)
-                return MOQ_ERR_PROTO;
+            n = vi->decode(p, rem, &val);
+            if (n == 0) return MOQ_ERR_PROTO;
+            p += n; rem -= n;
 
-            switch (entry.type) {
+            switch (type) {
             case LOC01_CAPTURE_TIMESTAMP:
                 out->has_timestamp = true;
                 out->timestamp = val;
@@ -131,17 +173,24 @@ moq_result_t moq_loc_parse(moq_loc_profile_t profile,
             default:
                 break;
             }
-        } else {
-            if (entry.type == LOC01_VIDEO_CONFIG) {
+        } else {                         /* odd type: length-prefixed bytes */
+            uint64_t vlen = 0;
+            n = vi->decode(p, rem, &vlen);
+            if (n == 0) return MOQ_ERR_PROTO;
+            p += n; rem -= n;
+
+            if (vlen > 0xFFFFu) return MOQ_ERR_PROTO;
+            if (vlen > rem) return MOQ_ERR_PROTO;
+
+            if (type == LOC01_VIDEO_CONFIG) {
                 out->has_video_config = true;
-                out->video_config.data = entry.value;
-                out->video_config.len = entry.value_len;
+                out->video_config.data = p;
+                out->video_config.len = (size_t)vlen;
             }
+            p += (size_t)vlen; rem -= (size_t)vlen;
         }
     }
 
-    if (rc != MOQ_DONE)
-        return rc;
     return MOQ_OK;
 }
 
@@ -160,38 +209,51 @@ typedef struct loc01_prop {
     size_t         bytes_len;
 } loc01_prop_t;
 
-static size_t loc01_prop_encoded_len(uint64_t prev, const loc01_prop_t *p)
+/* Encoded size of one entry, or 0 if the draft's integer encoding cannot
+ * represent the type delta, the value, or the byte-field length (the QUIC
+ * varint caps at 2^62-1; a byte field caps at 2^16-1 in both drafts). */
+static size_t loc01_prop_encoded_len(const loc_vint_t *vi, uint64_t prev,
+                                      const loc01_prop_t *p)
 {
-    if (p->is_varint)
-        return moq_kvp_varint_entry_encoded_len(prev, p->type, p->val);
+    if (p->type < prev) return 0;
+    size_t total = vi->len(p->type - prev);
+    if (total == 0) return 0;
 
-    moq_kvp_entry_t e;
-    memset(&e, 0, sizeof(e));
-    e.type = p->type;
-    e.is_varint = false;
-    e.value = p->bytes;
-    e.value_len = p->bytes_len;
-    return moq_kvp_entry_encoded_len(prev, &e);
+    if (p->is_varint) {
+        size_t vlen = vi->len(p->val);
+        return vlen ? total + vlen : 0;
+    }
+
+    if (p->bytes_len > 0xFFFFu) return 0;
+    if (p->bytes_len > 0 && !p->bytes) return 0;
+    size_t llen = vi->len(p->bytes_len);
+    return llen ? total + llen + p->bytes_len : 0;
 }
 
-static size_t loc01_prop_encode(uint64_t prev, const loc01_prop_t *p,
+static size_t loc01_prop_encode(const loc_vint_t *vi, uint64_t prev,
+                                 const loc01_prop_t *p,
                                  uint8_t *buf, size_t buf_len)
 {
-    if (p->is_varint)
-        return moq_kvp_encode_varint_entry(prev, p->type, p->val,
-                                            buf, buf_len);
+    size_t need = loc01_prop_encoded_len(vi, prev, p);
+    if (need == 0 || buf_len < need) return 0;
 
-    moq_kvp_entry_t e;
-    memset(&e, 0, sizeof(e));
-    e.type = p->type;
-    e.is_varint = false;
-    e.value = p->bytes;
-    e.value_len = p->bytes_len;
-    return moq_kvp_encode_entry(prev, &e, buf, buf_len);
+    size_t pos = vi->encode(p->type - prev, buf, buf_len);
+    if (p->is_varint) {
+        pos += vi->encode(p->val, buf + pos, buf_len - pos);
+        return pos;
+    }
+
+    pos += vi->encode(p->bytes_len, buf + pos, buf_len - pos);
+    if (p->bytes_len > 0) {
+        memcpy(buf + pos, p->bytes, p->bytes_len);
+        pos += p->bytes_len;
+    }
+    return pos;
 }
 
 moq_result_t moq_loc_encode(const moq_alloc_t *alloc,
                              moq_loc_profile_t profile,
+                             moq_version_t draft,
                              const moq_loc_headers_t *headers,
                              moq_rcbuf_t **out_properties)
 {
@@ -199,6 +261,10 @@ moq_result_t moq_loc_encode(const moq_alloc_t *alloc,
     *out_properties = NULL;
 
     if (profile != MOQ_LOC_PROFILE_01)
+        return MOQ_ERR_INVAL;
+
+    const loc_vint_t *vi = loc_vint_for(draft);
+    if (!vi)
         return MOQ_ERR_INVAL;
 
     if (headers->has_audio_level && headers->audio_level.level > 127)
@@ -261,7 +327,7 @@ moq_result_t moq_loc_encode(const moq_alloc_t *alloc,
     size_t total = 0;
     uint64_t prev = 0;
     for (size_t i = 0; i < prop_count; i++) {
-        size_t n = loc01_prop_encoded_len(prev, &props[i]);
+        size_t n = loc01_prop_encoded_len(vi, prev, &props[i]);
         if (n == 0) return MOQ_ERR_INVAL;
         total += n;
         prev = props[i].type;
@@ -280,7 +346,8 @@ moq_result_t moq_loc_encode(const moq_alloc_t *alloc,
     size_t pos = 0;
     prev = 0;
     for (size_t i = 0; i < prop_count; i++) {
-        size_t n = loc01_prop_encode(prev, &props[i], buf + pos, total - pos);
+        size_t n = loc01_prop_encode(vi, prev, &props[i],
+                                      buf + pos, total - pos);
         if (n == 0) {
             if (heap) alloc->free(buf, total, alloc->ctx);
             return MOQ_ERR_INVAL;

--- a/media/object/include/moq/media_object.h
+++ b/media/object/include/moq/media_object.h
@@ -52,6 +52,11 @@ typedef struct moq_media_track_info {
     moq_media_type_t     media_type;
     moq_media_packaging_t packaging;
     uint32_t             timescale;
+    /* The session's negotiated MoQ draft. LOC object properties are encoded
+     * differently per draft (see <moq/loc.h>), so a receiver must set this from
+     * moq_endpoint_negotiated_version(). moq_media_track_info_init defaults it
+     * to MOQ_VERSION_DRAFT_16; read only when struct_size covers it. */
+    moq_version_t        draft;
 } moq_media_track_info_t;
 
 MOQ_API void moq_media_track_info_init(moq_media_track_info_t *info);

--- a/media/object/src/media_object.c
+++ b/media/object/src/media_object.c
@@ -13,6 +13,7 @@ void moq_media_track_info_init(moq_media_track_info_t *info)
     if (!info) return;
     memset(info, 0, sizeof(*info));
     info->struct_size = sizeof(*info);
+    info->draft = MOQ_VERSION_DRAFT_16;
 }
 
 void moq_media_object_input_init(moq_media_object_input_t *in)
@@ -76,6 +77,10 @@ static bool cmaf_sample_is_keyframe(uint32_t flags)
     (offsetof(moq_media_track_info_t, timescale) + \
      sizeof(((moq_media_track_info_t *)0)->timescale))
 
+#define TRACK_INFO_DRAFT_SIZE \
+    (offsetof(moq_media_track_info_t, draft) + \
+     sizeof(((moq_media_track_info_t *)0)->draft))
+
 #define OBJECT_INPUT_MIN_SIZE \
     (offsetof(moq_media_object_input_t, properties) + \
      sizeof(((moq_media_object_input_t *)0)->properties))
@@ -131,7 +136,13 @@ moq_result_t moq_media_object_parse(
         }
 
         if (props.len > 0 || track->packaging == MOQ_MEDIA_PACKAGING_RAW) {
-            moq_result_t lr = moq_loc_parse(MOQ_LOC_PROFILE_01, props, &loc);
+            /* The property block's integer encoding follows the negotiated
+             * draft; a caller predating the field gets draft-16. */
+            moq_version_t draft = MOQ_VERSION_DRAFT_16;
+            if (track->struct_size >= TRACK_INFO_DRAFT_SIZE && track->draft)
+                draft = track->draft;
+            moq_result_t lr = moq_loc_parse(MOQ_LOC_PROFILE_01, draft,
+                                            props, &loc);
             if (lr == MOQ_ERR_PROTO) {
                 if (drop_reason) *drop_reason = MOQ_MEDIA_DROP_MALFORMED_LOC;
                 return MOQ_ERR_PROTO;

--- a/media/object/tests/test_media_object.c
+++ b/media/object/tests/test_media_object.c
@@ -246,7 +246,7 @@ int main(void)
         moq_rcbuf_decref(props);
     }
 
-    /* -- RAW on a draft-18 session: the info draft picks the encoding ---- *
+    /* -- RAW draft-18: the track info draft picks the encoding -------- *
      * The property block's integers follow the negotiated draft, so a draft-18
      * block only reads back when the track info says draft-18; with the default
      * (draft-16) the same bytes are malformed. */

--- a/media/object/tests/test_media_object.c
+++ b/media/object/tests/test_media_object.c
@@ -32,7 +32,8 @@ static moq_rcbuf_t *make_loc_props(const moq_alloc_t *alloc,
         lh.video_frame_marking.end_of_frame = true;
     }
     moq_rcbuf_t *out = NULL;
-    if (moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &out) != MOQ_OK)
+    if (moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                       &lh, &out) != MOQ_OK)
         return NULL;
     return out;
 }
@@ -228,7 +229,8 @@ int main(void)
         lh.has_timestamp = true;
         lh.timestamp = 5000;
         moq_rcbuf_t *props = NULL;
-        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &props) == MOQ_OK);
+        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                             &lh, &props) == MOQ_OK);
 
         moq_media_object_input_t oi;
         moq_media_object_input_init(&oi);
@@ -239,6 +241,48 @@ int main(void)
         CHECK(moq_media_object_parse(&ti, &oi, NULL, 0, &po, NULL) == MOQ_OK);
         CHECK(po.keyframe == false);
         CHECK(po.decode_time_us == 5000);
+
+        moq_rcbuf_decref(payload);
+        moq_rcbuf_decref(props);
+    }
+
+    /* -- RAW on a draft-18 session: the info draft picks the encoding ---- *
+     * The property block's integers follow the negotiated draft, so a draft-18
+     * block only reads back when the track info says draft-18; with the default
+     * (draft-16) the same bytes are malformed. */
+    {
+        moq_media_track_info_t ti;
+        moq_media_track_info_init(&ti);
+        ti.media_type = MOQ_MEDIA_TYPE_VIDEO;
+        ti.packaging = MOQ_MEDIA_PACKAGING_RAW;
+
+        uint8_t data[] = { 0x01 };
+        moq_rcbuf_t *payload = NULL;
+        CHECK(moq_rcbuf_create(alloc, data, 1, &payload) == MOQ_OK);
+
+        moq_loc_headers_t lh;
+        moq_loc_headers_init(&lh);
+        lh.has_timestamp = true;
+        lh.timestamp = 33333;
+        moq_rcbuf_t *props = NULL;
+        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_18,
+                             &lh, &props) == MOQ_OK);
+
+        moq_media_object_input_t oi;
+        moq_media_object_input_init(&oi);
+        oi.payload = payload;
+        oi.properties = props;
+
+        moq_media_parsed_object_t po;
+        moq_media_drop_reason_t why = 0;
+        CHECK(moq_media_object_parse(&ti, &oi, NULL, 0, &po, &why)
+              == MOQ_ERR_PROTO);
+        CHECK(why == MOQ_MEDIA_DROP_MALFORMED_LOC);
+
+        ti.draft = MOQ_VERSION_DRAFT_18;
+        CHECK(moq_media_object_parse(&ti, &oi, NULL, 0, &po, NULL) == MOQ_OK);
+        CHECK(po.has_capture_time == true);
+        CHECK(po.capture_time_us == 33333);
 
         moq_rcbuf_decref(payload);
         moq_rcbuf_decref(props);
@@ -459,7 +503,8 @@ int main(void)
         lh.has_video_frame_marking = true;
         lh.video_frame_marking.independent = false;
         moq_rcbuf_t *props = NULL;
-        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &props) == MOQ_OK);
+        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                             &lh, &props) == MOQ_OK);
 
         size_t len = build_fragment(buf, 90000, 3000, 2, 0x00000000, 0, mdat, 2);
         moq_rcbuf_t *payload = NULL;
@@ -483,7 +528,8 @@ int main(void)
         lh.has_video_frame_marking = true;
         lh.video_frame_marking.independent = true;
         props = NULL;
-        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &props) == MOQ_OK);
+        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                             &lh, &props) == MOQ_OK);
 
         len = build_fragment(buf, 90000, 3000, 2, 0x00010000, 0, mdat, 2);
         payload = NULL;

--- a/media/playback/tests/test_playback_api.c
+++ b/media/playback/tests/test_playback_api.c
@@ -290,6 +290,7 @@ static size_t build_aac_init(uint8_t *buf, uint32_t timescale,
         _lh.video_frame_marking.end_of_frame = true;          \
     }                                                         \
     CHECK(moq_loc_encode((alloc_p), MOQ_LOC_PROFILE_01,       \
+                         MOQ_VERSION_DRAFT_16,                \
                          &_lh, (out_ptr)) == MOQ_OK);         \
 } while (0)
 
@@ -2349,7 +2350,8 @@ int main(void)
         lh.has_timestamp = true;
         lh.timestamp = 7000;
         moq_rcbuf_t *props = NULL;
-        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &props) == MOQ_OK);
+        CHECK(moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                             &lh, &props) == MOQ_OK);
 
         moq_rcbuf_t *p = NULL;
         CHECK(moq_rcbuf_create(alloc, data, 1, &p) == MOQ_OK);

--- a/media/playback/tests/test_playback_oom.c
+++ b/media/playback/tests/test_playback_oom.c
@@ -67,7 +67,7 @@ static moq_rcbuf_t *make_props(const moq_alloc_t *alloc,
         lh.video_frame_marking.end_of_frame = true;
     }
     moq_rcbuf_t *out = NULL;
-    moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &out);
+    moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16, &lh, &out);
     return out;
 }
 

--- a/media/playback/tests/test_playback_scenario.c
+++ b/media/playback/tests/test_playback_scenario.c
@@ -150,7 +150,8 @@ static moq_rcbuf_t *make_props(const moq_alloc_t *alloc,
         lh.video_frame_marking.end_of_frame = true;
     }
     moq_rcbuf_t *out = NULL;
-    if (moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &lh, &out) != MOQ_OK)
+    if (moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                       &lh, &out) != MOQ_OK)
         return NULL;
     return out;
 }

--- a/service/src/endpoint.c
+++ b/service/src/endpoint.c
@@ -1826,6 +1826,13 @@ uint64_t moq_endpoint_fatal_code_internal(const moq_endpoint_t *ep)
     return ep_facade_fatal_code(ep);
 }
 
+moq_version_t moq_endpoint_negotiated_version_internal(
+    const moq_endpoint_t *ep)
+{
+    if (!ep) return (moq_version_t)0;
+    return ep->negotiated;
+}
+
 void moq_endpoint_detach_hook(moq_endpoint_t *ep,
                               moq_endpoint_hook_kind_t kind, void *ctx)
 {

--- a/service/src/endpoint_internal.h
+++ b/service/src/endpoint_internal.h
@@ -148,6 +148,14 @@ bool moq_endpoint_is_closed_internal(const moq_endpoint_t *ep);
 bool moq_endpoint_is_fatal_internal(const moq_endpoint_t *ep);
 uint64_t moq_endpoint_fatal_code_internal(const moq_endpoint_t *ep);
 
+/* The negotiated version WITHOUT taking ep->mu, for an attached service: the
+ * public moq_endpoint_negotiated_version() locks ep->mu, which a hook (the pump
+ * holds ep->mu across hooks) and a service-mu holder must not do. The pump sets
+ * the value under ep->mu immediately before it runs the hooks, so a hook always
+ * observes the established session's version. 0 until ESTABLISHED. */
+moq_version_t moq_endpoint_negotiated_version_internal(
+    const moq_endpoint_t *ep);
+
 /* Internal retryable post: like moq_endpoint_post(), but a task that returns
  * MOQ_ERR_WOULD_BLOCK is REQUEUED (the same node, no re-allocation) to run again
  * on a later pump cycle instead of being freed -- allocation-free retry for work

--- a/service/src/media_receiver.c
+++ b/service/src/media_receiver.c
@@ -325,6 +325,10 @@ struct moq_media_receiver {
     uint32_t         mt_cap, mt_head, mt_tail;
     bool             fatal;
     uint64_t         fatal_code;
+    /* Negotiated MoQ draft, latched by the hook from the endpoint. Stamped into
+     * every track handle's info so the LOC property block is parsed with the
+     * encoding the session negotiated. 0 until established. */
+    moq_version_t    negotiated_draft;
     moq_media_receiver_stats_t stats;    /* counter fields only */
 };
 
@@ -899,6 +903,10 @@ static moq_media_track_t *receiver_track_build(moq_media_receiver_t *r,
         moq_cmaf_init_info_init(&d->init);
         d->has_init = false;
     }
+    /* Stamped after every info init above: the parse side reads it to pick the
+     * property block's integer encoding. Set on the hook thread, which latched
+     * it before this catalog was ingested; 0 leaves the info default. */
+    if (r->negotiated_draft) d->info.draft = r->negotiated_draft;
     return t;
 }
 
@@ -2407,10 +2415,16 @@ static void receiver_reconcile_delivery(moq_media_receiver_t *r,
 static void receiver_hook(moq_endpoint_t *ep, moq_session_t *session,
                           uint64_t now_us, void *ctx)
 {
-    (void)ep;
     moq_media_receiver_t *r = (moq_media_receiver_t *)ctx;
 
+    /* Latch the negotiated draft: it picks the encoding the LOC property
+     * block is parsed with (receiver_track_build stamps it into each handle).
+     * The hook runs under ep->mu, so read it with the ep->mu-free accessor
+     * (0 before the session is established, and with no endpoint in tests). */
+    moq_version_t neg = moq_endpoint_negotiated_version_internal(ep);
+
     pthread_mutex_lock(&r->mu);
+    if (neg) r->negotiated_draft = neg;
     bool fatal = r->fatal;
     pthread_mutex_unlock(&r->mu);
     if (fatal || !session) return;

--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -325,6 +325,10 @@ struct moq_media_sender {
     bool              fatal;
     uint64_t          fatal_code;
 
+    /* Negotiated MoQ draft, latched by the hook from the endpoint. Selects the
+     * LOC property encoding (sender_loc_draft). 0 until established. */
+    moq_version_t     negotiated_draft;
+
     /* Latches so on_ready / on_closed each fire at most once (network thread). */
     bool              ready_fired;
     bool              closed_fired;
@@ -479,6 +483,16 @@ static moq_loc_profile_t sender_loc_profile(const moq_media_sender_t *s)
 {
     (void)s;   /* version-driven once LOC-02 lands; LOC-01-only for now */
     return MOQ_LOC_PROFILE_01;
+}
+
+/* The draft whose integer encoding the LOC property block uses (§1.4.1): the
+ * one the session negotiated, latched by the hook. The write path validates
+ * against the same draft it encodes for, so the two can never disagree. A
+ * sender with no endpoint (unit tests) stays on draft-16. Called with s->mu
+ * held (the latch is written under it). */
+static moq_version_t sender_loc_draft(const moq_media_sender_t *s)
+{
+    return s->negotiated_draft ? s->negotiated_draft : MOQ_VERSION_DRAFT_16;
 }
 
 /* -- Send queue (mu held by caller) ----------------------------------- *
@@ -987,7 +1001,8 @@ static bool sender_build_props(moq_media_sender_t *s,
         h.video_frame_marking.independent = e->is_sync;
     }
     moq_rcbuf_t *loc = NULL;
-    if (moq_loc_encode(&s->alloc, sender_loc_profile(s), &h, &loc) != MOQ_OK)
+    if (moq_loc_encode(&s->alloc, sender_loc_profile(s), sender_loc_draft(s),
+                       &h, &loc) != MOQ_OK)
         return false;
     *out = loc;   /* has_timestamp is always set, so loc is non-NULL */
     return true;
@@ -2161,10 +2176,16 @@ static void sender_pub_on_publish_finished(void *ctx, moq_pub_track_t *pt)
 static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
                         uint64_t now_us, void *ctx)
 {
-    (void)ep;
     moq_media_sender_t *s = (moq_media_sender_t *)ctx;
 
+    /* Latch the negotiated draft: it picks the LOC property encoding, and the
+     * drain path needs it under s->mu. The hook runs under ep->mu, so read it
+     * with the ep->mu-free accessor (0 before the session is established, and
+     * for a test sender driven without an endpoint). */
+    moq_version_t neg = moq_endpoint_negotiated_version_internal(ep);
+
     pthread_mutex_lock(&s->mu);
+    if (neg) s->negotiated_draft = neg;
     bool fatal = s->fatal;
     uint64_t fatal_code = s->fatal_code;
     pthread_mutex_unlock(&s->mu);
@@ -3638,12 +3659,15 @@ moq_result_t moq_media_sender_write(moq_media_sender_t *s,
         return MOQ_ERR_WRONG_STATE;
     }
 
-    /* The LOC Capture Timestamp is emitted as a QUIC varint by moq_loc_encode,
-     * but ONLY for RAW packaging (CMAF passes the app's property block through
-     * untouched, so its timestamp fields are never encoded here). A value beyond
-     * the varint range cannot be encoded; left to the drain path it would fatal
-     * the sender AFTER the object was queued and its payload ownership taken.
-     * Reject it synchronously -- before any enqueue / ownership transfer. The
+    /* The LOC Capture Timestamp is emitted by moq_loc_encode, but ONLY for RAW
+     * packaging (CMAF passes the app's property block through untouched, so its
+     * timestamp fields are never encoded here). A value the property encoding
+     * cannot carry would, left to the drain path, fatal the sender AFTER the
+     * object was queued and its payload ownership taken. Reject it
+     * synchronously -- before any enqueue / ownership transfer. The bound stays
+     * the QUIC-varint range for every draft: draft-16 cannot encode past it,
+     * and draft-18's vi64 spans all of uint64 but keeps the same single shared
+     * bound rather than admitting timestamps only one draft can emit. The
      * encoded value is capture_time_us when has_capture_time, else the
      * presentation_time_us fallback (sender_build_props), so validate whichever
      * will be encoded. MOQ_QUIC_VARINT_MAX itself is encodable (accepted). */

--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -485,11 +485,11 @@ static moq_loc_profile_t sender_loc_profile(const moq_media_sender_t *s)
     return MOQ_LOC_PROFILE_01;
 }
 
-/* The draft whose integer encoding the LOC property block uses (§1.4.1): the
- * one the session negotiated, latched by the hook. The write path validates
- * against the same draft it encodes for, so the two can never disagree. A
- * sender with no endpoint (unit tests) stays on draft-16. Called with s->mu
- * held (the latch is written under it). */
+/* The draft whose integer encoding the LOC property block uses: the one the
+ * session negotiated, latched by the hook (see <moq/loc.h>). The write path
+ * validates the block against the same draft it was encoded for, so the two can
+ * never disagree. A sender with no endpoint (unit tests) stays on draft-16.
+ * Called with s->mu held (the latch is written under it). */
 static moq_version_t sender_loc_draft(const moq_media_sender_t *s)
 {
     return s->negotiated_draft ? s->negotiated_draft : MOQ_VERSION_DRAFT_16;

--- a/service/tests/test_media_receiver.c
+++ b/service/tests/test_media_receiver.c
@@ -544,7 +544,8 @@ static bool srv_publish_media(srv_state_t *st, uint64_t now_us)
         h.has_video_frame_marking = true;
         h.video_frame_marking.independent = (i % OBJS_PER_GROUP) == 0;
         moq_rcbuf_t *props = NULL;
-        if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01, &h,
+        if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01,
+                           MOQ_VERSION_DRAFT_16, &h,
                            &props) != MOQ_OK)
             return false;
         uint8_t bytes[OBJ_PAYLOAD_LEN];

--- a/service/tests/test_media_receiver_largeobj.c
+++ b/service/tests/test_media_receiver_largeobj.c
@@ -151,7 +151,8 @@ static size_t build_loc_ext(uint8_t *out, size_t out_cap)
     h.video_frame_marking.independent = true;   /* -> keyframe */
 
     moq_rcbuf_t *ext = NULL;
-    if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01, &h, &ext) < 0
+    if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01,
+                       MOQ_VERSION_DRAFT_16, &h, &ext) < 0
         || !ext)
         return 0;
     size_t n = moq_rcbuf_len(ext);

--- a/service/tests/test_media_receiver_subscribe.c
+++ b/service/tests/test_media_receiver_subscribe.c
@@ -125,7 +125,8 @@ static bool publish_track(msrv_t *st, moq_pub_track_t *track, int *counter,
         h.has_video_frame_marking = true;
         h.video_frame_marking.independent = (i % OBJS_PER_GROUP) == 0;
         moq_rcbuf_t *props = NULL;
-        if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01, &h,
+        if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01,
+                           MOQ_VERSION_DRAFT_16, &h,
                            &props) != MOQ_OK)
             return false;
         uint8_t bytes[16];

--- a/service/tests/test_media_sender.c
+++ b/service/tests/test_media_sender.c
@@ -283,7 +283,8 @@ static int server_pump(moq_pq_threaded_t *t, moq_pq_threaded_lane_t *lane,
                         moq_loc_headers_init(&h);
                         moq_bytes_t pb = { moq_rcbuf_data(o->properties),
                                            moq_rcbuf_len(o->properties) };
-                        if (moq_loc_parse(MOQ_LOC_PROFILE_01, pb, &h)
+                        if (moq_loc_parse(MOQ_LOC_PROFILE_01,
+                                          MOQ_VERSION_DRAFT_16, pb, &h)
                             == MOQ_OK) {
                             r->has_ts = h.has_timestamp;
                             r->ts = h.timestamp;

--- a/service/tests/wtquic_network_smoke_server.c
+++ b/service/tests/wtquic_network_smoke_server.c
@@ -153,7 +153,8 @@ static void srv_publish_once(struct srv *v, uint64_t now)
     h.has_video_frame_marking = true;
     h.video_frame_marking.independent = true;
     moq_rcbuf_t *props = NULL;
-    if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01, &h,
+    if (moq_loc_encode(moq_alloc_default(), MOQ_LOC_PROFILE_01,
+                       MOQ_VERSION_DRAFT_16, &h,
                        &props) != MOQ_OK) {
         v->failed = 1;
         return;

--- a/tests/support/media_fuzz_loc.c
+++ b/tests/support/media_fuzz_loc.c
@@ -121,19 +121,22 @@ static int loc_soft(const moq_alloc_t *alloc, const uint8_t *buf, size_t len)
 {
     int failures = 0;
     moq_loc_headers_t p1;
-    if (moq_loc_parse(MOQ_LOC_PROFILE_01, (moq_bytes_t){ buf, len }, &p1)
+    if (moq_loc_parse(MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                      (moq_bytes_t){ buf, len }, &p1)
         != MOQ_OK)
         return 0;   /* reject is fine */
     /* A parsed model must re-encode (an empty model legitimately encodes to no
      * bytes: MOQ_OK with a NULL rcbuf -- treated as a zero-length property set). */
     moq_rcbuf_t *re = NULL;
-    moq_result_t er = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &p1, &re);
+    moq_result_t er = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01,
+                                     MOQ_VERSION_DRAFT_16, &p1, &re);
     MOQ_TEST_CHECK(er == MOQ_OK);
     if (er == MOQ_OK) {
         moq_bytes_t rb = re ? (moq_bytes_t){ moq_rcbuf_data(re), moq_rcbuf_len(re) }
                             : (moq_bytes_t){ NULL, 0 };
         moq_loc_headers_t p2;
-        moq_result_t rc2 = moq_loc_parse(MOQ_LOC_PROFILE_01, rb, &p2);
+        moq_result_t rc2 = moq_loc_parse(MOQ_LOC_PROFILE_01,
+                                         MOQ_VERSION_DRAFT_16, rb, &p2);
         MOQ_TEST_CHECK(rc2 == MOQ_OK);
         if (rc2 == MOQ_OK)
             MOQ_TEST_CHECK(loc_headers_equal(&p1, &p2));
@@ -179,6 +182,7 @@ static int loc_mutate(const moq_alloc_t *alloc, moq_fuzz_rng_t *rng,
         if (n > 0) {
             moq_loc_headers_t p1;
             moq_result_t rc = moq_loc_parse(MOQ_LOC_PROFILE_01,
+                MOQ_VERSION_DRAFT_16,
                 (moq_bytes_t){ buf, blen + n }, &p1);
             MOQ_TEST_CHECK(rc == MOQ_OK);          /* unknown KVP ignored */
             if (rc == MOQ_OK)
@@ -201,6 +205,7 @@ static int loc_mutate(const moq_alloc_t *alloc, moq_fuzz_rng_t *rng,
             buf[blen + 1] = 0x05;                  /* length 5, no value bytes */
             moq_loc_headers_t p1;
             moq_result_t rc = moq_loc_parse(MOQ_LOC_PROFILE_01,
+                MOQ_VERSION_DRAFT_16,
                 (moq_bytes_t){ buf, blen + 2 }, &p1);
             MOQ_TEST_CHECK(rc != MOQ_OK);          /* truncated value -> reject */
         }
@@ -225,7 +230,8 @@ static int loc_one_case(const moq_alloc_t *alloc, moq_fuzz_rng_t *rng,
     loc_gen(rng, &model, vcfg);
 
     moq_rcbuf_t *enc = NULL;
-    moq_result_t rc = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &model, &enc);
+    moq_result_t rc = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01,
+                                     MOQ_VERSION_DRAFT_16, &model, &enc);
     MOQ_TEST_CHECK(rc == MOQ_OK && enc != NULL);   /* generated valid must encode */
     if (rc != MOQ_OK || !enc) {
         if (enc) moq_rcbuf_decref(enc);
@@ -236,14 +242,16 @@ static int loc_one_case(const moq_alloc_t *alloc, moq_fuzz_rng_t *rng,
 
     moq_bytes_t bytes = { moq_rcbuf_data(enc), moq_rcbuf_len(enc) };
     moq_loc_headers_t back;
-    moq_result_t prc = moq_loc_parse(MOQ_LOC_PROFILE_01, bytes, &back);
+    moq_result_t prc = moq_loc_parse(MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
+                                     bytes, &back);
     MOQ_TEST_CHECK(prc == MOQ_OK);
     if (prc == MOQ_OK)
         MOQ_TEST_CHECK(loc_headers_equal(&model, &back));
 
     /* Encode is deterministic: the same model yields identical bytes. */
     moq_rcbuf_t *enc2 = NULL;
-    moq_result_t rc2 = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01, &model, &enc2);
+    moq_result_t rc2 = moq_loc_encode(alloc, MOQ_LOC_PROFILE_01,
+                                      MOQ_VERSION_DRAFT_16, &model, &enc2);
     MOQ_TEST_CHECK(rc2 == MOQ_OK && enc2 != NULL);
     if (rc2 == MOQ_OK && enc2) {
         size_t n1 = moq_rcbuf_len(enc), n2 = moq_rcbuf_len(enc2);

--- a/tests/unit/test_loc.c
+++ b/tests/unit/test_loc.c
@@ -1,6 +1,8 @@
 #include <moq/loc.h>
 #include <moq/kvp.h>
 #include <moq/wire.h>
+#include <moq/control_d18.h>   /* the draft-18 property validation the write
+                                * path applies to an emitted block */
 #include <moq/rcbuf.h>
 #include "test_support.h"
 #include "test_oom_support.h"
@@ -8,6 +10,10 @@
 
 #define P01 MOQ_LOC_PROFILE_01
 #define P02 MOQ_LOC_PROFILE_02
+/* Negotiated draft: it selects the property block's integer encoding (QUIC
+ * varint for draft-16, vi64 for draft-18). */
+#define D16 MOQ_VERSION_DRAFT_16
+#define D18 MOQ_VERSION_DRAFT_18
 
 int main(void)
 {
@@ -34,29 +40,31 @@ int main(void)
     {
         moq_loc_headers_t h;
         moq_bytes_t empty = { NULL, 0 };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, empty, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, empty, &h) == MOQ_OK);
         MOQ_TEST_CHECK(h.has_timestamp == false);
     }
 
     /* -- parse NULL out returns INVAL -------------------------------- */
     {
         moq_bytes_t empty = { NULL, 0 };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, empty, NULL) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, empty, NULL) == MOQ_ERR_INVAL);
     }
 
     /* -- NULL data with nonzero len returns INVAL -------------------- */
     {
         moq_loc_headers_t h;
         moq_bytes_t bad = { NULL, 5 };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, bad, &h) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, bad, &h) == MOQ_ERR_INVAL);
     }
 
     /* -- invalid profile parse returns INVAL ------------------------- */
     {
         moq_loc_headers_t h;
         moq_bytes_t empty = { NULL, 0 };
-        MOQ_TEST_CHECK(moq_loc_parse((moq_loc_profile_t)0, empty, &h) == MOQ_ERR_INVAL);
-        MOQ_TEST_CHECK(moq_loc_parse((moq_loc_profile_t)99, empty, &h) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse((moq_loc_profile_t)0, D16, empty,
+                                     &h) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse((moq_loc_profile_t)99, D16, empty,
+                                     &h) == MOQ_ERR_INVAL);
     }
 
     /* -- invalid profile encode returns INVAL ------------------------ */
@@ -67,9 +75,11 @@ int main(void)
         h.timestamp = 1;
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, (moq_loc_profile_t)0, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, (moq_loc_profile_t)0, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
         MOQ_TEST_CHECK(out == NULL);
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, (moq_loc_profile_t)99, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, (moq_loc_profile_t)99, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
         MOQ_TEST_CHECK(out == NULL);
     }
 
@@ -77,7 +87,7 @@ int main(void)
     {
         moq_loc_headers_t h;
         moq_bytes_t empty = { NULL, 0 };
-        MOQ_TEST_CHECK(moq_loc_parse(P02, empty, &h) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse(P02, D16, empty, &h) == MOQ_ERR_INVAL);
     }
 
     /* -- LOC-02 encode returns INVAL --------------------------------- */
@@ -88,7 +98,8 @@ int main(void)
         h.timestamp = 48000;
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P02, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P02, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
         MOQ_TEST_CHECK(out == NULL);
     }
 
@@ -101,7 +112,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
         MOQ_TEST_CHECK(out != NULL);
 
         /* Expected wire: delta=0x02 (1 byte), value=1000000.
@@ -118,7 +129,7 @@ int main(void)
 
         moq_loc_headers_t parsed;
         moq_bytes_t props = { d, len };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
         MOQ_TEST_CHECK_EQ_U64(parsed.timestamp, 1000000);
         moq_rcbuf_decref(out);
     }
@@ -133,7 +144,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         /* Expected: delta=0x06, value=0x9E (V=1|level=30).
          * Wire: [0x06] [0x40 0x9E] = 3 bytes.
@@ -158,7 +169,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         /* Expected: delta=0x04, value=0xE0.
          * Wire: [0x04] [0x40 0xE0] = 3 bytes.
@@ -181,7 +192,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK(h.has_video_frame_marking == true);
         MOQ_TEST_CHECK(h.video_frame_marking.start_of_frame == true);
         MOQ_TEST_CHECK(h.video_frame_marking.end_of_frame == true);
@@ -201,7 +212,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK(h.video_frame_marking.has_layer_id == true);
         MOQ_TEST_CHECK_EQ_INT(h.video_frame_marking.layer_id, 0);
         MOQ_TEST_CHECK(h.video_frame_marking.base_layer_sync == true);
@@ -221,7 +232,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK(h.has_video_config == true);
         MOQ_TEST_CHECK_EQ_SIZE(h.video_config.len, sizeof(extradata));
         MOQ_TEST_CHECK(memcmp(h.video_config.data, extradata,
@@ -251,7 +262,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK_EQ_U64(h.timestamp, 5000);
         MOQ_TEST_CHECK(h.video_frame_marking.independent == true);
         MOQ_TEST_CHECK(h.audio_level.voice_activity == true);
@@ -268,7 +279,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_ERR_PROTO);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_ERR_PROTO);
     }
 
     /* -- audio level value > 0xFF returns PROTO ----------------------- */
@@ -280,7 +291,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_ERR_PROTO);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_ERR_PROTO);
     }
 
     /* -- unknown extension ignored ----------------------------------- */
@@ -292,7 +303,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK(h.has_timestamp == false);
     }
 
@@ -308,7 +319,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
     }
 
     /* -- duplicate known: last wins ---------------------------------- */
@@ -322,7 +333,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) == MOQ_OK);
         MOQ_TEST_CHECK_EQ_U64(h.timestamp, 200);
     }
 
@@ -331,7 +342,7 @@ int main(void)
         uint8_t wire[] = { 0x40 };
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, sizeof(wire) };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) < 0);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) < 0);
     }
 
     /* -- truncated length-prefixed video config ---------------------- */
@@ -345,7 +356,7 @@ int main(void)
 
         moq_loc_headers_t h;
         moq_bytes_t props = { wire, pos };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &h) < 0);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &h) < 0);
     }
 
     /* -- encode no fields returns OK + NULL -------------------------- */
@@ -354,7 +365,7 @@ int main(void)
         moq_loc_headers_init(&h);
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = (moq_rcbuf_t *)1;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
         MOQ_TEST_CHECK(out == NULL);
     }
 
@@ -364,9 +375,12 @@ int main(void)
         moq_loc_headers_init(&h);
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(NULL, P01, &h, &out) == MOQ_ERR_INVAL);
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, NULL, &out) == MOQ_ERR_INVAL);
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, NULL) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(NULL, P01, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, NULL,
+                                      &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h,
+                                      NULL) == MOQ_ERR_INVAL);
     }
 
     /* -- encode audio level > 127 returns INVAL ---------------------- */
@@ -377,7 +391,8 @@ int main(void)
         h.audio_level.level = 128;
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
     }
 
     /* -- encode temporal_id > 7 returns INVAL ------------------------ */
@@ -388,7 +403,8 @@ int main(void)
         h.video_frame_marking.temporal_id = 8;
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
     }
 
     /* -- LOC-01: timescale encode returns INVAL ----------------------- */
@@ -399,7 +415,8 @@ int main(void)
         h.timescale = 48000;
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h,
+                                      &out) == MOQ_ERR_INVAL);
     }
 
     /* -- video frame marking with layer_id roundtrip ------------------ */
@@ -416,11 +433,11 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         moq_loc_headers_t parsed;
         moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
         MOQ_TEST_CHECK(parsed.video_frame_marking.has_layer_id == true);
         MOQ_TEST_CHECK_EQ_INT(parsed.video_frame_marking.layer_id, 15);
         moq_rcbuf_decref(out);
@@ -447,11 +464,11 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         moq_loc_headers_t parsed;
         moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
         MOQ_TEST_CHECK_EQ_U64(parsed.timestamp, 1746104600000000ULL);
         MOQ_TEST_CHECK(parsed.video_frame_marking.independent == true);
         MOQ_TEST_CHECK(parsed.audio_level.voice_activity == true);
@@ -473,7 +490,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         const uint8_t *d = moq_rcbuf_data(out);
         uint64_t v = 0;
@@ -494,7 +511,8 @@ int main(void)
         moq_alloc_t fail_alloc = oom_allocator(&oom);
 
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out) == MOQ_ERR_NOMEM);
+        MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h,
+                                      &out) == MOQ_ERR_NOMEM);
         MOQ_TEST_CHECK(out == NULL);
         MOQ_TEST_CHECK(oom.balance == 0);
     }
@@ -515,7 +533,8 @@ int main(void)
             oom_alloc_state_t oom = { 0, 0, 1 };
             moq_alloc_t fail_alloc = oom_allocator(&oom);
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out) == MOQ_ERR_NOMEM);
+            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h,
+                                          &out) == MOQ_ERR_NOMEM);
             MOQ_TEST_CHECK(out == NULL);
             MOQ_TEST_CHECK(oom.balance == 0);
         }
@@ -525,7 +544,8 @@ int main(void)
             oom_alloc_state_t oom = { 0, 0, 2 };
             moq_alloc_t fail_alloc = oom_allocator(&oom);
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out) == MOQ_ERR_NOMEM);
+            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h,
+                                          &out) == MOQ_ERR_NOMEM);
             MOQ_TEST_CHECK(out == NULL);
             MOQ_TEST_CHECK(oom.balance == 0);
         }
@@ -534,12 +554,12 @@ int main(void)
         {
             const moq_alloc_t *alloc = moq_alloc_default();
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
             MOQ_TEST_CHECK(out != NULL);
 
             moq_loc_headers_t parsed;
             moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-            MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
             MOQ_TEST_CHECK(parsed.has_video_config == true);
             MOQ_TEST_CHECK_EQ_SIZE(parsed.video_config.len, sizeof(big_config));
             MOQ_TEST_CHECK(memcmp(parsed.video_config.data, big_config,
@@ -558,11 +578,11 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         moq_loc_headers_t parsed;
         moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
         MOQ_TEST_CHECK(parsed.audio_level.voice_activity == false);
         MOQ_TEST_CHECK_EQ_INT(parsed.audio_level.level, 127);
         moq_rcbuf_decref(out);
@@ -580,11 +600,11 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
 
         moq_loc_headers_t parsed;
         moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-        MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
         MOQ_TEST_CHECK_EQ_INT(parsed.video_frame_marking.layer_id, 255);
         moq_rcbuf_decref(out);
     }
@@ -601,7 +621,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
         MOQ_TEST_CHECK(out != NULL);
 
         /* Wire: [delta 0x0d] [len 0x03] [AA BB CC] = 5 bytes. */
@@ -689,7 +709,7 @@ int main(void)
 
             const moq_alloc_t *alloc = moq_alloc_default();
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
             MOQ_TEST_CHECK(out != NULL);
             if (out) {
                 MOQ_TEST_CHECK_EQ_SIZE(moq_rcbuf_len(out), planned);
@@ -736,7 +756,7 @@ int main(void)
 
             const moq_alloc_t *alloc = moq_alloc_default();
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
             MOQ_TEST_CHECK(out != NULL);
             if (!out) continue;
 
@@ -744,7 +764,7 @@ int main(void)
 
             moq_loc_headers_t parsed;
             moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
-            MOQ_TEST_CHECK(moq_loc_parse(P01, props, &parsed) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed) == MOQ_OK);
             MOQ_TEST_CHECK(parsed.has_video_config == true);
             MOQ_TEST_CHECK_EQ_SIZE(parsed.video_config.len, kValueLens[c]);
             MOQ_TEST_CHECK(memcmp(parsed.video_config.data, cfg,
@@ -769,7 +789,7 @@ int main(void)
             oom_alloc_state_t oom = { 0, 0, 1 };
             moq_alloc_t fail_alloc = oom_allocator(&oom);
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out)
+            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h, &out)
                            == MOQ_ERR_NOMEM);
             MOQ_TEST_CHECK(out == NULL);
             MOQ_TEST_CHECK(oom.balance == 0);
@@ -780,7 +800,7 @@ int main(void)
             oom_alloc_state_t oom = { 0, 0, 2 };
             moq_alloc_t fail_alloc = oom_allocator(&oom);
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out)
+            MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h, &out)
                            == MOQ_ERR_NOMEM);
             MOQ_TEST_CHECK(out == NULL);
             MOQ_TEST_CHECK(oom.balance == 0);
@@ -802,7 +822,7 @@ int main(void)
         oom_alloc_state_t oom = { 0, 0, 1 };
         moq_alloc_t fail_alloc = oom_allocator(&oom);
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, &h, &out)
+        MOQ_TEST_CHECK(moq_loc_encode(&fail_alloc, P01, D16, &h, &out)
                        == MOQ_ERR_NOMEM);
         MOQ_TEST_CHECK(out == NULL);
         MOQ_TEST_CHECK(oom.balance == 0);
@@ -820,7 +840,7 @@ int main(void)
             h.video_config.data = NULL;
             h.video_config.len = 4;
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out)
+            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out)
                            == MOQ_ERR_INVAL);
             MOQ_TEST_CHECK(out == NULL);
         }
@@ -834,7 +854,7 @@ int main(void)
             h.video_config.data = big;
             h.video_config.len = sizeof(big);
             moq_rcbuf_t *out = NULL;
-            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out)
+            MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out)
                            == MOQ_ERR_INVAL);
             MOQ_TEST_CHECK(out == NULL);
         }
@@ -850,7 +870,7 @@ int main(void)
 
         const moq_alloc_t *alloc = moq_alloc_default();
         moq_rcbuf_t *out = NULL;
-        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, &h, &out) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out) == MOQ_OK);
         MOQ_TEST_CHECK(out != NULL);
         if (out) {
             /* Wire: [delta 0x0d] [len 0x00] = 2 bytes. */
@@ -859,6 +879,157 @@ int main(void)
             MOQ_TEST_CHECK_EQ_HEX(moq_rcbuf_data(out)[1], 0x00);
             moq_rcbuf_decref(out);
         }
+    }
+
+    /* == draft-18 property blocks ====================================== *
+     * The property block's integers follow the negotiated draft
+     * (draft-ietf-moq-transport-18 §1.4.1 / §1.4.3): draft-16 and draft-18
+     * agree only up to 63, so the same headers must produce different bytes per
+     * draft, and a draft-18 session's block must satisfy the draft-18 property
+     * validation the write path applies to it. */
+
+    /* -- D18 timestamp byte-level oracle (the 33333us capture time) ---- */
+    {
+        moq_loc_headers_t h;
+        moq_loc_headers_init(&h);
+        h.has_timestamp = true;
+        h.timestamp = 33333;          /* second frame at 30fps */
+
+        const moq_alloc_t *alloc = moq_alloc_default();
+        moq_rcbuf_t *b18 = NULL, *b16 = NULL;
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D18, &h, &b18) == MOQ_OK);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &b16) == MOQ_OK);
+        if (b18 && b16) {
+            /* D18: [delta 0x02] [33333 in 3 bytes: 0xC0 0x82 0x35]. */
+            const uint8_t *d = moq_rcbuf_data(b18);
+            MOQ_TEST_CHECK_EQ_SIZE(moq_rcbuf_len(b18), 4);
+            MOQ_TEST_CHECK_EQ_HEX(d[0], 0x02);
+            MOQ_TEST_CHECK_EQ_HEX(d[1], 0xC0);
+            MOQ_TEST_CHECK_EQ_HEX(d[2], 0x82);
+            MOQ_TEST_CHECK_EQ_HEX(d[3], 0x35);
+            /* D16: [delta 0x02] [33333 in 4 bytes: 0x80 0x00 0x82 0x35]. */
+            MOQ_TEST_CHECK_EQ_SIZE(moq_rcbuf_len(b16), 5);
+
+            /* The draft-18 block passes the validation a draft-18 session runs
+             * over an outgoing property block; the draft-16 block does not (the
+             * mismatch that failed every frame past 63us). */
+            MOQ_TEST_CHECK(moq_d18_validate_properties(
+                d, moq_rcbuf_len(b18)) == MOQ_OK);
+            MOQ_TEST_CHECK(moq_d18_validate_properties(
+                moq_rcbuf_data(b16), moq_rcbuf_len(b16)) == MOQ_ERR_PROTO);
+
+            /* Each draft reads its own bytes; the other draft's do not decode
+             * as valid metadata. */
+            moq_loc_headers_t parsed;
+            moq_bytes_t props = { d, moq_rcbuf_len(b18) };
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D18, props, &parsed) == MOQ_OK);
+            MOQ_TEST_CHECK_EQ_U64(parsed.timestamp, 33333);
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D16, props, &parsed)
+                           == MOQ_ERR_PROTO);
+        }
+        if (b18) moq_rcbuf_decref(b18);
+        if (b16) moq_rcbuf_decref(b16);
+    }
+
+    /* -- D18 round-trip: every field, including an odd-type length ---- */
+    {
+        static const uint8_t cfg[200] = { 0x67, 0x42 };
+        moq_loc_headers_t h;
+        moq_loc_headers_init(&h);
+        h.has_timestamp = true;
+        h.timestamp = 1000000;
+        h.has_video_frame_marking = true;
+        h.video_frame_marking.start_of_frame = true;
+        h.video_frame_marking.end_of_frame = true;
+        h.video_frame_marking.independent = true;
+        h.has_audio_level = true;
+        h.audio_level.voice_activity = true;
+        h.audio_level.level = 30;
+        h.has_video_config = true;
+        h.video_config.data = cfg;
+        h.video_config.len = sizeof(cfg);
+
+        const moq_alloc_t *alloc = moq_alloc_default();
+        moq_rcbuf_t *out = NULL;
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D18, &h, &out) == MOQ_OK);
+        if (out) {
+            const uint8_t *d = moq_rcbuf_data(out);
+            size_t len = moq_rcbuf_len(out);
+            /* [0x02][0xCF 0x42 0x40] timestamp, [0x02][0x80 0xE0] marking,
+             * [0x02][0x80 0x9E] audio level, [0x07][0x80 0xC8] + 200 bytes of
+             * video config = 213. The marking value (0xE0) and the 200-byte
+             * length both pass 63, so both take a 2-byte D18 form. */
+            MOQ_TEST_CHECK_EQ_SIZE(len, 213);
+            MOQ_TEST_CHECK_EQ_HEX(d[10], 0x07);
+            MOQ_TEST_CHECK_EQ_HEX(d[11], 0x80);
+            MOQ_TEST_CHECK_EQ_HEX(d[12], 0xC8);
+            MOQ_TEST_CHECK(moq_d18_validate_properties(d, len) == MOQ_OK);
+
+            moq_loc_headers_t parsed;
+            moq_bytes_t props = { d, len };
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D18, props, &parsed) == MOQ_OK);
+            MOQ_TEST_CHECK_EQ_U64(parsed.timestamp, 1000000);
+            MOQ_TEST_CHECK(parsed.has_video_frame_marking == true);
+            MOQ_TEST_CHECK(parsed.video_frame_marking.start_of_frame == true);
+            MOQ_TEST_CHECK(parsed.video_frame_marking.end_of_frame == true);
+            MOQ_TEST_CHECK(parsed.video_frame_marking.independent == true);
+            MOQ_TEST_CHECK(parsed.has_audio_level == true);
+            MOQ_TEST_CHECK(parsed.audio_level.voice_activity == true);
+            MOQ_TEST_CHECK_EQ_INT(parsed.audio_level.level, 30);
+            MOQ_TEST_CHECK(parsed.has_video_config == true);
+            MOQ_TEST_CHECK_EQ_SIZE(parsed.video_config.len, sizeof(cfg));
+            MOQ_TEST_CHECK(parsed.video_config.data != NULL &&
+                           parsed.video_config.data[0] == 0x67);
+            moq_rcbuf_decref(out);
+        }
+    }
+
+    /* -- D18 carries values draft-16 cannot ------------------------------ */
+    {
+        moq_loc_headers_t h;
+        moq_loc_headers_init(&h);
+        h.has_timestamp = true;
+        h.timestamp = UINT64_MAX;
+
+        const moq_alloc_t *alloc = moq_alloc_default();
+        moq_rcbuf_t *out = NULL;
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D16, &h, &out)
+                       == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(out == NULL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, D18, &h, &out) == MOQ_OK);
+        if (out) {
+            /* [delta 0x02] + the 9-byte D18 form = 10 bytes. */
+            MOQ_TEST_CHECK_EQ_SIZE(moq_rcbuf_len(out), 10);
+            moq_loc_headers_t parsed;
+            moq_bytes_t props = { moq_rcbuf_data(out), moq_rcbuf_len(out) };
+            MOQ_TEST_CHECK(moq_loc_parse(P01, D18, props, &parsed) == MOQ_OK);
+            MOQ_TEST_CHECK_EQ_U64(parsed.timestamp, UINT64_MAX);
+            moq_rcbuf_decref(out);
+        }
+    }
+
+    /* -- a draft this library has no encoding for is refused ------------ */
+    {
+        moq_loc_headers_t h;
+        moq_loc_headers_init(&h);
+        h.has_timestamp = true;
+        h.timestamp = 1;
+
+        const moq_alloc_t *alloc = moq_alloc_default();
+        moq_rcbuf_t *out = NULL;
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, (moq_version_t)0, &h, &out)
+                       == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(out == NULL);
+        MOQ_TEST_CHECK(moq_loc_encode(alloc, P01, (moq_version_t)17, &h, &out)
+                       == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(out == NULL);
+
+        moq_loc_headers_t parsed;
+        moq_bytes_t empty = { NULL, 0 };
+        MOQ_TEST_CHECK(moq_loc_parse(P01, (moq_version_t)0, empty, &parsed)
+                       == MOQ_ERR_INVAL);
+        MOQ_TEST_CHECK(moq_loc_parse(P01, (moq_version_t)17, empty, &parsed)
+                       == MOQ_ERR_INVAL);
     }
 
     printf("%s: %d failures\n", failures ? "FAIL" : "PASS", failures);

--- a/tests/unit/test_loc.c
+++ b/tests/unit/test_loc.c
@@ -888,7 +888,7 @@ int main(void)
      * draft, and a draft-18 session's block must satisfy the draft-18 property
      * validation the write path applies to it. */
 
-    /* -- D18 timestamp byte-level oracle (the 33333us capture time) ---- */
+    /* -- D18 timestamp oracle (the 33333us capture time) ------------- */
     {
         moq_loc_headers_t h;
         moq_loc_headers_init(&h);
@@ -984,7 +984,7 @@ int main(void)
         }
     }
 
-    /* -- D18 carries values draft-16 cannot ------------------------------ */
+    /* -- D18 carries values draft-16 cannot -------------------------- */
     {
         moq_loc_headers_t h;
         moq_loc_headers_init(&h);
@@ -1008,7 +1008,7 @@ int main(void)
         }
     }
 
-    /* -- a draft this library has no encoding for is refused ------------ */
+    /* -- a draft this library has no encoding for is refused --------- */
     {
         moq_loc_headers_t h;
         moq_loc_headers_init(&h);

--- a/tests/unit/test_media_conformance.c
+++ b/tests/unit/test_media_conformance.c
@@ -274,7 +274,7 @@ static const moq_test_media_case_t MSF_CASES[] = {
 static moq_result_t loc_encode(const moq_alloc_t *al, const void *m,
                                moq_rcbuf_t **out)
 {
-    return moq_loc_encode(al, MOQ_LOC_PROFILE_01,
+    return moq_loc_encode(al, MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16,
                           (const moq_loc_headers_t *)m, out);
 }
 
@@ -283,7 +283,8 @@ static bool loc_reparse_equal(moq_bytes_t bytes, const void *m)
     const moq_loc_headers_t *want = (const moq_loc_headers_t *)m;
     moq_loc_headers_t got;
     moq_loc_headers_init(&got);
-    if (moq_loc_parse(MOQ_LOC_PROFILE_01, bytes, &got) != MOQ_OK) return false;
+    if (moq_loc_parse(MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16, bytes,
+                      &got) != MOQ_OK) return false;
 
     if (got.has_timestamp != want->has_timestamp ||
         got.timestamp != want->timestamp) return false;
@@ -317,7 +318,7 @@ static moq_result_t loc_parse_only(moq_bytes_t bytes)
 {
     moq_loc_headers_t h;
     moq_loc_headers_init(&h);
-    return moq_loc_parse(MOQ_LOC_PROFILE_01, bytes, &h);
+    return moq_loc_parse(MOQ_LOC_PROFILE_01, MOQ_VERSION_DRAFT_16, bytes, &h);
 }
 
 static const moq_test_media_format_ops_t LOC_OPS = {


### PR DESCRIPTION
## the bug

on a draft-18 session the media sender writes LOC object properties as draft-16 KVP, while moq5's own draft-18 write path validates that block as vi64. the two encodings agree only up to 63, so the second frame (capture timestamp 33333us) is rejected with MOQ_ERR_INVAL, the sender goes fatal, and the publisher dies about a second after the first subscriber attaches. `moq_loc_parse` had the mirror bug on the receive side.

## the fix

the LOC profile fixes the property IDs, the negotiated transport draft fixes how their integers are encoded (§1.4.1 / §1.4.3). so `moq_loc_parse` and `moq_loc_encode` now take the negotiated version and select the codec from it, with one KVP walker shared by both drafts.

the media sender and receiver latch that version from the endpoint. both read it inside the endpoint hook, which holds `ep->mu`, hence the new `ep->mu`-free accessor next to `moq_endpoint_is_closed_internal`. `moq_media_track_info_t` gains an appended, struct_size-gated `draft` field for the parse side; it defaults to draft-16, so draft-16 bytes and behavior are unchanged.

no LOC-02, no change to the fatal-code contract.

## testing

default, nosim, shared, cppbind and asan presets green, plus the service + playback + MSF tree. new draft-18 coverage in `test_loc` and `test_media_object`: byte oracles for the 33333us timestamp, the emitted block passing `moq_d18_validate_properties` where the draft-16 one does not, round-trips, values past the draft-16 range, unsupported drafts.

end to end against a live relay, an ffmpeg testsrc through `examples/service/media_publish_loc` into `examples/service/media_receive`: at draft 18 the publisher now sends every frame (1200 sent, 0 dropped, previously one object and then fatal) and the subscriber reads timestamps stepping 33333us. draft 16 unchanged.

`moq_playback` and the swift MoQMedia parser still default to draft-16 because their APIs have no version input. neither is in this path, so I left them for a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/8)
<!-- Reviewable:end -->
