### PR TITLE
service: live-write push catalog without waiting for demand

### DIFF
--- a/service/src/media_sender.c
+++ b/service/src/media_sender.c
@@ -2330,10 +2330,16 @@ static void sender_hook(moq_endpoint_t *ep, moq_session_t *session,
      * callback in the same cycle it is accepted (before the drain runs). */
     sender_resync_demand(s);
 
-    /* Publish-initiated: once the peer accepts the catalog PUBLISH, push the
-     * initial catalog object live so a relay caches it without a FETCH. */
+    /* Publish-initiated: write the initial catalog live so a catalog-blind
+     * relay can cache it (media_sender.h: publish_tracks "without a FETCH").
+     * Retained-group install is a different operation (docs/publisher-
+     * retained-groups.md): SUBSCRIBE + Joining FETCH(offset 0) reads the
+     * origin cache; live write fills the relay. Do not wait for
+     * sender_track_demand — PUBLISH_OK often arrives with Forward 0, and
+     * write_object_ex still fans out to the established publication. Gating
+     * on demand skipped the live object, left the relay empty, and late
+     * joiners saw a live namespace with no catalog. */
     if (s->publish_tracks && !s->live_catalog_sent && s->catalog_published &&
-        sender_track_demand(s, s->catalog_track) &&
         s->published_catalog) {
         moq_pub_object_cfg_t ocfg;
         moq_pub_object_cfg_init_sized(&ocfg, sizeof(ocfg));


### PR DESCRIPTION
`publish_tracks` is supposed to write the initial catalog so a catalog-blind relay can cache it. That is not the same as installing the retained group (SUBSCRIBE + Joining FETCH still reads the origin cache).

The live write was gated on `sender_track_demand`. `PUBLISH_OK` often has Forward 0, so group 0 never left the origin.

Does not replay retained objects onto a plain SUBSCRIBE.

Verified: draft-18 moqx + playa CatalogBootstrap, headed CMAF painted.

## Test
- [ ] `test_media_sender_push_cursor` still sees generation 0
- [ ] `publish_tracks = false` unchanged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/9)
<!-- Reviewable:end -->
