### PR TITLE
Add MOQ_WITH_OPENSSL to build the adapters without OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(libmoq
 option(MOQ_BUILD_TESTS             "Build test suite"               ON)
 option(MOQ_BUILD_SIM               "Build moq-sim"                  ${MOQ_BUILD_TESTS})
 option(MOQ_BUILD_ADAPTER_PICOQUIC  "Build picoquic adapter"         OFF)
+option(MOQ_WITH_OPENSSL            "Build the OpenSSL cert verifier" ON)
 option(MOQ_BUILD_CPP_BINDING       "Build C++ binding"              OFF)
 option(MOQ_BUILD_LOC               "Build moq-loc LOC helpers"      ON)
 option(MOQ_BUILD_MSF               "Build moq-msf catalog parser"   OFF)

--- a/adapters/pico_wt/CMakeLists.txt
+++ b/adapters/pico_wt/CMakeLists.txt
@@ -36,7 +36,12 @@ target_include_directories(moq-adapter-pico-wt
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-find_package(OpenSSL REQUIRED)
+if(MOQ_WITH_OPENSSL)
+    find_package(OpenSSL REQUIRED)
+    set(_moq_openssl_link OpenSSL::SSL OpenSSL::Crypto)
+else()
+    set(_moq_openssl_link "")
+endif()
 
 # picohttp-core is PUBLIC: <moq/pico_wt.h> publicly includes
 # pico_webtransport.h / h3zero_common.h, so consumers of the adapter
@@ -46,7 +51,7 @@ find_package(OpenSSL REQUIRED)
 # the build-tree target name must never leak into an export.
 target_link_libraries(moq-adapter-pico-wt
     PUBLIC  moq::core $<BUILD_INTERFACE:${_PICOHTTP}>
-    PRIVATE OpenSSL::SSL OpenSSL::Crypto
+    PRIVATE ${_moq_openssl_link}
 )
 
 # Export public symbols past C_VISIBILITY_PRESET hidden (MOQ_API).
@@ -67,7 +72,10 @@ endif()
 # adapter-pico-wt)` works against ${PROJECT_BINARY_DIR}, mirroring the
 # picoquic adapter. The install-tree counterpart is generated in the
 # install section below.
-set(_picowt_link "moq::core;OpenSSL::SSL;OpenSSL::Crypto;${_PICOHTTP}")
+set(_picowt_link "moq::core;${_PICOHTTP}")
+if(MOQ_WITH_OPENSSL)
+    set(_picowt_link "moq::core;OpenSSL::SSL;OpenSSL::Crypto;${_PICOHTTP}")
+endif()
 file(GENERATE
     OUTPUT "${PROJECT_BINARY_DIR}/libmoqPicoWtAdapterTargets.cmake"
     CONTENT "\
@@ -471,7 +479,7 @@ if(MOQ_BUILD_PICO_WT_MANAGED)
     target_link_libraries(moq-adapter-pico-wt-managed
         PUBLIC  moq::adapter-pico-wt moq::adapter-picoquic
         PRIVATE $<BUILD_INTERFACE:${_PICOHTTP}> ${_PICO_CORE}
-                Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
+                Threads::Threads ${_moq_openssl_link})
     # Export public symbols past C_VISIBILITY_PRESET hidden (MOQ_API).
     target_compile_definitions(moq-adapter-pico-wt-managed PRIVATE
         MOQ_BUILDING)

--- a/adapters/picoquic/CMakeLists.txt
+++ b/adapters/picoquic/CMakeLists.txt
@@ -12,8 +12,13 @@ else()
     message(FATAL_ERROR "No picoquic-core target available")
 endif()
 
+if(MOQ_WITH_OPENSSL)
+    set(_moq_pq_verify moq_picoquic_verify.c)
+else()
+    set(_moq_pq_verify moq_picoquic_verify_unavailable.c)
+endif()
 add_library(moq-adapter-picoquic
-    moq_picoquic.c picoquic_endpoint.c moq_picoquic_verify.c
+    moq_picoquic.c picoquic_endpoint.c ${_moq_pq_verify}
     ../common/moq_pq_send_queue.c)
 add_library(moq::adapter-picoquic ALIAS moq-adapter-picoquic)
 
@@ -31,6 +36,7 @@ target_include_directories(moq-adapter-picoquic
 # picoquic modes). PRIVATE: not part of the public interface (the public
 # header forward-declares picoquic_quic_t only). A deliberate, actionable
 # error if absent — never a cryptic missing-header failure mid-build.
+if(MOQ_WITH_OPENSSL)
 find_path(MOQ_PTLS_OPENSSL_INCLUDE_DIR
     NAMES picotls/openssl.h
     HINTS
@@ -52,6 +58,10 @@ target_include_directories(moq-adapter-picoquic
     PRIVATE ${MOQ_PTLS_OPENSSL_INCLUDE_DIR})
 
 find_package(OpenSSL REQUIRED)
+set(_moq_openssl_link OpenSSL::SSL OpenSSL::Crypto)
+else()
+set(_moq_openssl_link "")
+endif()
 
 # Resolve picoquic-log target name before linking.
 set(_PQ_LOG "")
@@ -62,7 +72,7 @@ elseif(TARGET picoquic-log)
 endif()
 
 target_link_libraries(moq-adapter-picoquic
-    PUBLIC moq::core OpenSSL::SSL OpenSSL::Crypto
+    PUBLIC moq::core ${_moq_openssl_link}
     PUBLIC $<BUILD_INTERFACE:${_PQ}>)
 
 if(_PQ_LOG)
@@ -105,7 +115,10 @@ install(FILES moq_picoquic.h
 # consumption (absolute paths) and one for install-tree (relocatable).
 
 # Build-tree targets (absolute paths — valid on this machine)
-set(_adapter_pq_link "moq::core;OpenSSL::SSL;OpenSSL::Crypto;${_PQ}")
+set(_adapter_pq_link "moq::core;${_PQ}")
+if(MOQ_WITH_OPENSSL)
+    set(_adapter_pq_link "moq::core;OpenSSL::SSL;OpenSSL::Crypto;${_PQ}")
+endif()
 if(_PQ_LOG)
     string(APPEND _adapter_pq_link ";${_PQ_LOG}")
 endif()

--- a/adapters/picoquic/moq_picoquic_verify_unavailable.c
+++ b/adapters/picoquic/moq_picoquic_verify_unavailable.c
@@ -1,0 +1,24 @@
+/*
+ * The MOQ_WITH_OPENSSL=OFF build of moq_picoquic_verify.c.
+ *
+ * The OpenSSL-backed verifier wraps picotls' OpenSSL X509 code. A build
+ * without OpenSSL -- picotls' minicrypto backend, for instance -- has no X509
+ * code at all, so there is nothing to verify a chain against. Both entry points
+ * report that rather than silently accepting one, so a caller that asked for a
+ * CA bundle fails instead of getting no verification.
+ */
+
+#include <moq/picoquic_verify.h>
+
+int moq_picoquic_ca_file_loadable(const char *ca_file)
+{
+    (void)ca_file;
+    return 0;
+}
+
+int moq_picoquic_set_cert_verifier(picoquic_quic_t *quic, const char *ca_file)
+{
+    (void)quic;
+    (void)ca_file;
+    return -1;
+}


### PR DESCRIPTION
Both adapters call `find_package(OpenSSL REQUIRED)` unconditionally, so neither can be built for Android against picotls-minicrypto, where there is no OpenSSL to find.

Only one file needs it: `adapters/picoquic/moq_picoquic_verify.c`, which wraps picotls' OpenSSL X509 verifier. `adapters/pico_wt` has no source that includes an OpenSSL header at all — it requires and links the library purely to propagate it.

`MOQ_WITH_OPENSSL` defaults to `ON`, so the default build is unchanged. With it `OFF` the picoquic adapter compiles `moq_picoquic_verify_unavailable.c` instead, keeping both entry points but reporting that no verifier is available — so a caller passing a CA bundle fails rather than silently getting no verification.

Verified by building an arm64-v8a NDK r27 JNI library against this branch with `MOQ_WITH_OPENSSL=OFF`: links clean under `-Wl,--no-undefined`, no OpenSSL symbol in the result, same set of archives as before.

Left alone for now: the generated config files still emit `find_dependency(OpenSSL)`, which only affects install trees. Happy to extend if you'd like it in the same PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/15)
<!-- Reviewable:end -->
