### PR TITLE
Delegate the certificate chain decision to fix CA validation on Android

### DIFF
--- a/adapters/picoquic/include/moq/picoquic_verify.h
+++ b/adapters/picoquic/include/moq/picoquic_verify.h
@@ -53,6 +53,7 @@
  */
 
 #include <moq/export.h>
+#include <moq/cert_verifier.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,6 +89,14 @@ MOQ_API int moq_picoquic_set_cert_verifier(picoquic_quic_t *quic,
  * loaded. Lets the service endpoint report a bad CA file as a configuration
  * error (MOQ_ERR_INVAL) up front, rather than as a generic connect failure. */
 MOQ_API int moq_picoquic_ca_file_loadable(const char *ca_file);
+
+/*
+ * Delegate the chain decision to `verifier` instead of validating against a CA
+ * file -- see <moq/cert_verifier.h>. picotls still verifies CertificateVerify.
+ * `verifier` is borrowed and must outlive `quic`. 0 on success.
+ */
+MOQ_API int moq_picoquic_set_platform_cert_verifier(
+    picoquic_quic_t *quic, const moq_cert_verifier_t *verifier);
 
 #ifdef __cplusplus
 }

--- a/adapters/picoquic/moq_picoquic_verify.c
+++ b/adapters/picoquic/moq_picoquic_verify.c
@@ -72,3 +72,98 @@ int moq_picoquic_set_cert_verifier(picoquic_quic_t *quic, const char *ca_file)
                                              moq_picoquic_dispose_verifier);
     return 0;
 }
+
+/* -- Platform-delegated chain decision ------------------------------- *
+ * The application rules on the chain; picotls still verifies
+ * CertificateVerify with the leaf's public key, which is why this needs the
+ * OpenSSL backend. picotls computes its own verdict first and override_callback
+ * replaces it. */
+
+typedef struct {
+    ptls_openssl_override_verify_certificate_t super; /* first: aliased below */
+    const moq_cert_verifier_t *app;
+} moq_override_t;
+
+typedef struct {
+    ptls_openssl_verify_certificate_t super;          /* first: aliased by dispose */
+    moq_override_t override;
+} moq_platform_verifier_t;
+
+static int moq_status_to_alert(moq_cert_status_t st)
+{
+    switch (st) {
+    case MOQ_CERT_OK:                return 0;
+    case MOQ_CERT_EXPIRED:           return PTLS_ALERT_CERTIFICATE_EXPIRED;
+    case MOQ_CERT_UNKNOWN_ISSUER:    return PTLS_ALERT_UNKNOWN_CA;
+    case MOQ_CERT_REVOKED:           return PTLS_ALERT_CERTIFICATE_REVOKED;
+    case MOQ_CERT_BAD_ENCODING:      return PTLS_ALERT_BAD_CERTIFICATE;
+    case MOQ_CERT_INVALID_EXTENSION: return PTLS_ALERT_UNSUPPORTED_CERTIFICATE;
+    default:                         return PTLS_ALERT_CERTIFICATE_UNKNOWN;
+    }
+}
+
+static int moq_override_cb(ptls_openssl_override_verify_certificate_t *self,
+                           ptls_t *tls, int ret, int ossl_ret, X509 *cert,
+                           STACK_OF(X509) * chain)
+{
+    moq_override_t *o = (moq_override_t *)self;
+    (void)ret; (void)ossl_ret;   /* picotls' verdict is replaced, not consulted */
+
+    if (cert == NULL) return PTLS_ALERT_CERTIFICATE_REQUIRED;
+
+    int n_interm = chain != NULL ? sk_X509_num(chain) : 0;
+    if (n_interm < 0) n_interm = 0;
+    size_t n = (size_t)n_interm + 1;
+
+    /* Back to DER: the hook exposes only the parsed form. */
+    moq_bytes_t *der = calloc(n, sizeof(*der));
+    unsigned char **buf = calloc(n, sizeof(*buf));
+    if (der == NULL || buf == NULL) { free(der); free(buf); return PTLS_ERROR_NO_MEMORY; }
+
+    int rc = 0;
+    for (size_t i = 0; i < n; ++i) {
+        X509 *x = (i == 0) ? cert : sk_X509_value(chain, (int)(i - 1));
+        int len = i2d_X509(x, &buf[i]);
+        if (len <= 0) { rc = PTLS_ALERT_BAD_CERTIFICATE; break; }
+        der[i].data = buf[i];
+        der[i].len  = (size_t)len;
+    }
+    if (rc == 0)
+        rc = moq_status_to_alert(o->app->verify_chain(o->app->user_data,
+                                                      ptls_get_server_name(tls),
+                                                      der, n));
+
+    for (size_t i = 0; i < n; ++i) OPENSSL_free(buf[i]);
+    free(buf); free(der);
+    return rc;
+}
+
+static void moq_platform_dispose(ptls_verify_certificate_t *verifier)
+{
+    if (!verifier) return;
+    ptls_openssl_dispose_verify_certificate(
+        (ptls_openssl_verify_certificate_t *)verifier);
+    free(verifier);
+}
+
+int moq_picoquic_set_platform_cert_verifier(picoquic_quic_t *quic,
+                                            const moq_cert_verifier_t *verifier)
+{
+    if (quic == NULL || verifier == NULL || verifier->verify_chain == NULL)
+        return -1;
+
+    moq_platform_verifier_t *v = calloc(1, sizeof(*v));
+    if (v == NULL) return -1;
+    /* NULL store: the verdict is overridden anyway, but init needs a context. */
+    if (ptls_openssl_init_verify_certificate(&v->super, NULL) != 0) {
+        free(v);
+        return -1;
+    }
+    v->override.super.cb = moq_override_cb;
+    v->override.app      = verifier;
+    v->super.override_callback = &v->override.super;
+
+    picoquic_set_verify_certificate_callback(quic, &v->super.super,
+                                             moq_platform_dispose);
+    return 0;
+}

--- a/core/include/moq/cert_verifier.h
+++ b/core/include/moq/cert_verifier.h
@@ -1,0 +1,66 @@
+#ifndef MOQ_CERT_VERIFIER_H
+#define MOQ_CERT_VERIFIER_H
+
+/*
+ * moq_cert_verifier_t: the certificate chain decision, delegated to the
+ * application.
+ *
+ * The native verifier validates the chain against a CA file or the system
+ * trust store. Some platforms cannot express their trust rules that way: a CA
+ * set is only part of the answer, and supplying one bypasses everything else
+ * the platform would apply -- per-app pinning, administrator/enterprise CA
+ * policy, revocation lists, and per-domain overrides. A certificate the
+ * platform would reject is then accepted.
+ *
+ * Delegating the decision keeps that logic where it lives. Only the trust
+ * decision moves: the TLS stack still verifies CertificateVerify with the
+ * leaf's public key, so nothing about the handshake proof is delegated.
+ */
+
+#include <moq/types.h>
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Outcome of a delegated chain check. The values are a stable numeric
+ * contract: a platform verifier's own status can be mapped onto them once and
+ * passed through. Each maps to a distinct TLS alert, so a peer learns why the
+ * chain was refused rather than getting a generic failure.
+ */
+typedef enum moq_cert_status {
+    MOQ_CERT_OK                = 0, /* trusted */
+    MOQ_CERT_UNAVAILABLE       = 1, /* verifier could not run at all; NOT a
+                                       statement about the chain */
+    MOQ_CERT_EXPIRED           = 2, /* outside its validity period */
+    MOQ_CERT_UNKNOWN_ISSUER    = 3, /* does not chain to a trusted root */
+    MOQ_CERT_REVOKED           = 4,
+    MOQ_CERT_BAD_ENCODING      = 5, /* not parsable as a certificate */
+    MOQ_CERT_INVALID_EXTENSION = 6  /* parsable, but an extension forbids this
+                                       use (e.g. EKU without server auth) */
+} moq_cert_status_t;
+
+typedef struct moq_cert_verifier {
+    /*
+     * Is `chain` trusted for `server_name`? DER-encoded, leaf first,
+     * `num_certs` entries, valid only for the duration of the call.
+     * `server_name` is NUL-terminated, or NULL if the peer offered none.
+     *
+     * Called on the transport thread during the handshake, so it must not
+     * block on anything that could wait on that thread.
+     */
+    moq_cert_status_t (*verify_chain)(void *user_data, const char *server_name,
+                                      const moq_bytes_t *chain,
+                                      size_t num_certs);
+    /* Opaque, passed back to verify_chain. */
+    void *user_data;
+} moq_cert_verifier_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOQ_CERT_VERIFIER_H */

--- a/service/include/moq/endpoint.h
+++ b/service/include/moq/endpoint.h
@@ -35,6 +35,7 @@
 
 #include <moq/types.h>
 #include <moq/session.h>
+#include <moq/cert_verifier.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -235,6 +236,18 @@ typedef struct moq_endpoint_cfg {
      * the v0 floor, connect() reads it ONLY when struct_size covers it fully --
      * set it via moq_endpoint_cfg_init_sized(&cfg, sizeof cfg). */
     uint64_t handshake_timeout_us;
+    /* appended (enabled by struct_size): delegate the certificate chain
+     * decision to the application instead of validating against ca_file or the
+     * system trust store -- see <moq/cert_verifier.h>. Borrowed, so it must
+     * outlive the endpoint; NULL keeps the native verifier.
+     *
+     * Honored only by the picoquic backend, whose connect path has the
+     * configure_quic hook this installs through; a non-NULL value on any other
+     * backend is a connect-time MOQ_ERR_UNSUPPORTED, not a silent no-op, as
+     * with wt_profile. Mutually exclusive with insecure_skip_verify and with a
+     * non-empty ca_file (MOQ_ERR_INVAL both ways): each of those also means
+     * "not the native verifier", but they disagree about what to do instead. */
+    const moq_cert_verifier_t *cert_verifier;
 } moq_endpoint_cfg_t;
 
 /* Largest accepted moq_endpoint_cfg_t.handshake_timeout_us (see its doc above).

--- a/service/src/endpoint.c
+++ b/service/src/endpoint.c
@@ -338,6 +338,24 @@ moq_result_t moq_endpoint_resolve_cfg(const moq_endpoint_cfg_t *cfg,
         out->handshake_timeout_us = cfg->handshake_timeout_us;
     }
 
+    /* Delegated verifier: the same complete-presence gate. Rejected rather
+     * than ignored where it could not take effect. */
+    out->cert_verifier = NULL;
+    if ((size_t)cfg->struct_size >=
+        offsetof(moq_endpoint_cfg_t, cert_verifier) +
+            sizeof(cfg->cert_verifier)) {
+        if (cfg->cert_verifier != NULL) {
+            if (cfg->cert_verifier->verify_chain == NULL) return MOQ_ERR_INVAL;
+            /* These also mean "not the native verifier" but disagree about
+             * what to do instead; refuse rather than pick one. */
+            if (cfg->insecure_skip_verify || cfg->ca_file.len != 0)
+                return MOQ_ERR_INVAL;
+            if (out->backend != MOQ_TRANSPORT_BACKEND_PICOQUIC)
+                return MOQ_ERR_UNSUPPORTED;
+            out->cert_verifier = cfg->cert_verifier;
+        }
+    }
+
     return resolve_versions(&cfg->versions, out);
 }
 
@@ -399,6 +417,7 @@ struct moq_endpoint {
     char *path;    size_t path_len;    /* WT path; NULL for RAW_QUIC */
     char *ca_file; size_t ca_file_len; /* NULL = system roots */
     bool  insecure;
+    const moq_cert_verifier_t *cert_verifier;  /* borrowed; NULL = native */
     uint64_t handshake_timeout_us;     /* 0 = backend default; picoquic only */
 
     /* The version offer as transport tokens, preference order. The ALPN
@@ -706,6 +725,8 @@ static int ep_configure_quic(picoquic_quic_t *quic, void *ctx)
     if (ep->handshake_timeout_us > 0)
         picoquic_set_default_handshake_timeout(quic, ep->handshake_timeout_us);
     if (ep->insecure) return 0;
+    if (ep->cert_verifier != NULL)
+        return moq_picoquic_set_platform_cert_verifier(quic, ep->cert_verifier);
     return moq_picoquic_set_cert_verifier(quic, ep->ca_file);
 }
 #endif
@@ -1646,6 +1667,7 @@ moq_result_t moq_endpoint_connect(const moq_endpoint_cfg_t *cfg,
     ep->protocol = r.protocol;
     ep->insecure = cfg->insecure_skip_verify;
     ep->handshake_timeout_us = r.handshake_timeout_us;
+    ep->cert_verifier = r.cert_verifier;
     atomic_init(&ep->interrupted, false);
     atomic_init(&ep->closed, false);
     pthread_mutex_init(&ep->mu, NULL);

--- a/service/src/endpoint_internal.h
+++ b/service/src/endpoint_internal.h
@@ -6,6 +6,7 @@
  * compile against this via the moq-service-test-internals target.
  */
 
+#include <moq/cert_verifier.h>
 #include <moq/endpoint.h>
 #include <moq/url.h>
 
@@ -38,6 +39,9 @@ typedef struct moq_endpoint_resolved {
      * the picoquic backends -- resolve rejects a non-zero value on any backend
      * that cannot apply it. */
     uint64_t      handshake_timeout_us;
+    /* Delegated chain verifier, struct_size-gated at resolve; NULL when the
+     * cfg predates the field or supplies none. Borrowed from the cfg. */
+    const moq_cert_verifier_t *cert_verifier;
 } moq_endpoint_resolved_t;
 
 /*


### PR DESCRIPTION
Fixes CA validation on Android. Refs #14.

## The bug

Android ships no system PEM bundle, so a client has to reconstruct one from the platform trust anchors. That supplies the **CA set** but not the platform's **trust evaluation**, so all of these are silently bypassed:

- Network Security Config (`<domain-config>`, `cleartextTrafficPermitted`, custom trust anchors)
- per-app certificate pinning
- MDM / enterprise CA policy
- the platform CA blocklist

A certificate the platform would reject is accepted. For an SDK shipped to third-party apps each of those is a correctness bug, not a hardening nicety.

## The fix

`moq_endpoint_cfg_t.cert_verifier` hands the chain to the application, which answers with a status:

```c
typedef struct moq_cert_verifier {
    /* Is `chain` trusted for `server_name`? DER, leaf first. */
    moq_cert_status_t (*verify_chain)(void *user_data, const char *server_name,
                                      const moq_bytes_t *chain,
                                      size_t num_certs);
    void *user_data;
} moq_cert_verifier_t;
```

On Android that callback is a one-line bridge to `X509TrustManager.checkServerTrusted`, which *is* the platform's trust evaluation — so all four items above are honoured by construction.

Same split as [rustls-platform-verifier](https://github.com/rustls/rustls-platform-verifier): only the trust decision is delegated, and picotls still verifies CertificateVerify with the leaf's public key. `moq_cert_status_t` mirrors that crate's `VerifierStatus` values, so an existing bridge maps across one-to-one and a rejection becomes a specific TLS alert instead of a generic failure:

| | rustls-platform-verifier | here | alert |
|---|---|---|---|
| 0 | `Ok` | `MOQ_CERT_OK` | — |
| 1 | `Unavailable` | `MOQ_CERT_UNAVAILABLE` | `certificate_unknown` |
| 2 | `Expired` | `MOQ_CERT_EXPIRED` | `certificate_expired` |
| 3 | `UnknownCert` | `MOQ_CERT_UNKNOWN_ISSUER` | `unknown_ca` |
| 4 | `Revoked` | `MOQ_CERT_REVOKED` | `certificate_revoked` |
| 5 | `InvalidEncoding` | `MOQ_CERT_BAD_ENCODING` | `bad_certificate` |
| 6 | `InvalidExtension` | `MOQ_CERT_INVALID_EXTENSION` | `unsupported_certificate` |

Implemented on picotls' `override_callback`, which is what it is for: picotls computes its own chain verdict and this replaces it.

## Compatibility

`cert_verifier` is a `struct_size`-gated tail field, so the v0 layout floor does not move and an existing caller is unaffected. Resolve rejects rather than ignores it where it could not take effect: a non-picoquic backend is `MOQ_ERR_UNSUPPORTED`; combining it with `insecure_skip_verify` or a `ca_file` is `MOQ_ERR_INVAL`, since those also mean "not the native verifier" but disagree about what to do instead.

## Status

Draft — compiles against OpenSSL 3, no tests yet. Two things I would like your opinion on:

- `override_callback` is not handed the verification name, so this uses `ptls_get_server_name(tls)`. They differ only when ECH was offered and rejected. Acceptable, or worth a picotls change?
- Is the tail field the right entry point, or would you rather forward `configure_quic` through the service tier? That exposes a backend-specific handle on a backend-agnostic struct, which is why I did not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/16)
<!-- Reviewable:end -->
