### PR TITLE
Close open connections on stop() and arm keepalive on the managed WT facade

### DIFF
--- a/adapters/pico_wt/CMakeLists.txt
+++ b/adapters/pico_wt/CMakeLists.txt
@@ -758,6 +758,17 @@ endif()\n")
             TIMEOUT 30
             LABELS "network;pico_wt;managed")
 
+        # stop() on a facade whose connection is open must send
+        # CONNECTION_CLOSE before joining the thread: the server observes the
+        # departure within seconds, not after its idle timeout.
+        add_test(NAME pico_wt_managed_stop_close
+            COMMAND test_pico_wt_managed_loopback --mode stop_close
+                --cert "${MOQ_PICOQUIC_SOURCE_DIR}/certs/cert.pem"
+                --key  "${MOQ_PICOQUIC_SOURCE_DIR}/certs/key.pem")
+        set_tests_properties(pico_wt_managed_stop_close PROPERTIES
+            TIMEOUT 30
+            LABELS "network;pico_wt;managed")
+
         # Graceful drain: publish 256 KiB under a forced ~64 KiB window, poll the
         # drain predicate until the publisher's transport reports flushed, and
         # prove full delivery at that point (backs moq_endpoint_drain).
@@ -866,6 +877,26 @@ endif()\n")
                 "${MOQ_PICOQUIC_SOURCE_DIR}/certs/key.pem")
         set_tests_properties(pico_wt_ownership PROPERTIES
             TIMEOUT 60 LABELS "network;pico_wt;managed")
+
+        # Keepalive arming oracle for the managed WT facade (mirrors
+        # threaded_keepalive): keep_alive_interval_ms is applied to the client
+        # connection with the converted microsecond interval, 0 arms nothing,
+        # and a short struct_size never reads the appended field. Same
+        # test-internals recompile as the ownership oracle.
+        add_executable(test_pico_wt_managed_keepalive
+            tests/test_pico_wt_managed_keepalive.c
+            pico_wt_managed.c
+            pico_wt_adapter.c
+            pico_wt_endpoint.c
+            ../common/moq_pq_send_queue.c
+        )
+        target_compile_definitions(test_pico_wt_managed_keepalive PRIVATE MOQ_PICO_WT_TESTING)
+        target_include_directories(test_pico_wt_managed_keepalive PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+        target_link_libraries(test_pico_wt_managed_keepalive PRIVATE moq::adapter-pico-wt-managed)
+        add_test(NAME pico_wt_managed_keepalive COMMAND test_pico_wt_managed_keepalive)
+        set_tests_properties(pico_wt_managed_keepalive PROPERTIES
+            TIMEOUT 30 LABELS "pico_wt;managed")
 
         # WT protocol-token negotiation through the managed pair: the
         # d16-only server selects from the client's {18, 16} offer, and a

--- a/adapters/pico_wt/include/moq/pico_wt_managed.h
+++ b/adapters/pico_wt/include/moq/pico_wt_managed.h
@@ -198,6 +198,18 @@ typedef struct moq_pico_wt_managed_cfg {
     uint64_t         (*app_deadline_us)(void *ctx);
     void              *app_deadline_ctx;
 
+    /* Appended (struct_size append-only ABI). QUIC keepalive interval in
+     * milliseconds for every connection this facade owns (the client
+     * connection, and each accepted server connection). 0 = no keepalive
+     * (the default). A nonzero value calls picoquic_enable_keep_alive with
+     * the converted microsecond interval, so an otherwise idle session (a
+     * publisher waiting for its first subscriber, a subscriber between
+     * groups) keeps sending PING and is not idle-timed-out by the peer;
+     * red5-moq-relay and moxygen both close a silent connection after 30 s.
+     * Mirrors moq_pq_threaded_cfg_t.keep_alive_interval_ms. Read only when
+     * struct_size covers it. */
+    uint32_t           keep_alive_interval_ms;
+
 } moq_pico_wt_managed_cfg_t;
 
 /* Pointer initializer: clears and stamps the full current struct; set any field,
@@ -227,6 +239,13 @@ MOQ_API moq_result_t moq_pico_wt_managed_create(
  * Stop and join the network thread. Idempotent. MUST NOT be called
  * from on_pump/on_activity (returns MOQ_ERR_WRONG_STATE). After return,
  * no more callbacks fire; then call _destroy.
+ *
+ * A connection that is still open when stop() is called is closed on the
+ * wire first: the loop sends CONNECTION_CLOSE (application code 0) and is
+ * given a short bounded window (MOQ_PICO_WT_LOCAL_CLOSE_FLUSH_US) to put
+ * it on the wire before the thread is joined, so the peer sees a prompt
+ * close instead of an idle timeout. The same applies when on_pump
+ * requests termination. Stopping does not wait for the peer's reply.
  */
 MOQ_API moq_result_t moq_pico_wt_managed_stop(moq_pico_wt_managed_t *m);
 

--- a/adapters/pico_wt/pico_wt_managed.c
+++ b/adapters/pico_wt/pico_wt_managed.c
@@ -40,6 +40,12 @@
  * budget so a large object is admitted in full. */
 #define PICO_WT_MANAGED_RECV_FLOW_CONTROL (16u * 1024u * 1024u)
 
+/* Bounded window a local stop/pump-exit gives the packet loop to put the
+ * CONNECTION_CLOSE on the wire before the network thread is joined. */
+#ifndef MOQ_PICO_WT_LOCAL_CLOSE_FLUSH_US
+#define MOQ_PICO_WT_LOCAL_CLOSE_FLUSH_US 250000u
+#endif
+
 /* Advertise the inbound uni-stream + connection receive credit on the default
  * transport parameters, so every cnx created from this quic context (client
  * cnx and inbound server cnxs) inherits it. picowt's per-cnx parameter setup
@@ -86,6 +92,7 @@ struct moq_pico_wt_managed {
     void              *on_activity_ctx;
     uint64_t         (*app_deadline_us)(void *);   /* optional service deadline */
     void              *app_deadline_ctx;
+    uint32_t           keep_alive_interval_ms;  /* 0 = keepalive disabled */
 
     /* Owned transport. */
     picoquic_quic_t   *quic;
@@ -122,6 +129,12 @@ struct moq_pico_wt_managed {
     uint64_t           close_flush_deadline_us;    /* network thread only */
     bool               stopped;
     bool               loop_came_up;   /* loop reached ready (latched) */
+    bool               loop_running;   /* between the ready callback and the
+                                        * loop's own termination; stop() waits
+                                        * (bounded) for it to clear so a queued
+                                        * CONNECTION_CLOSE reaches the wire */
+    bool               local_close_started;      /* network thread only */
+    uint64_t           local_close_deadline_us;  /* network thread only */
     bool               pump_exit;
     bool               tx_drained;      /* network thread: local stream flush
                                          * done (no queued/ready stream data or
@@ -143,6 +156,8 @@ struct moq_pico_wt_managed {
     size_t            test_ev_overflow;
 #endif
 };
+
+static void pwt_arm_keep_alive(moq_pico_wt_managed_t *m, picoquic_cnx_t *cnx);
 
 /* -- cfg helpers ---------------------------------------------------- */
 
@@ -534,6 +549,8 @@ static int managed_server_wt_cb(picoquic_cnx_t *cnx, uint8_t *bytes,
     m->test_ctrl_sid  = stream_ctx->stream_id;
     m->test_ctrl_have = 1;
 #endif
+    /* An explicit keepalive applies to accepted server connections too. */
+    pwt_arm_keep_alive(m, cnx);
     pthread_mutex_lock(&m->mutex);
     m->session = session;
     m->conn = conn;
@@ -550,6 +567,89 @@ fail:
     pthread_mutex_unlock(&m->mutex);
     mark_activity(m);
     return -1;
+}
+
+/* -- Keepalive ------------------------------------------------------ */
+
+#if defined(MOQ_PICO_WT_TESTING)
+/* TEST-ONLY seam: when set, replaces picoquic_enable_keep_alive so a unit test
+ * can prove the facade arms keepalive exactly once per connection, on a
+ * non-NULL cnx, with the converted microsecond interval -- without a live
+ * handshake or a real idle timeout. Production compiles none of this and
+ * calls picoquic_enable_keep_alive() directly. */
+void (*moq_pico_wt_test_keep_alive)(picoquic_cnx_t *, uint64_t);
+unsigned moq_pico_wt_test_keep_alive_calls;
+picoquic_cnx_t *moq_pico_wt_test_keep_alive_last_cnx;
+uint64_t moq_pico_wt_test_keep_alive_last_interval_us;
+#endif
+
+/* Arm QUIC keepalive on one connection this facade owns, when configured.
+ * interval_ms == 0 disables keepalive (no call). Called for the client
+ * connection and every accepted server connection. */
+static void pwt_arm_keep_alive(moq_pico_wt_managed_t *m, picoquic_cnx_t *cnx)
+{
+    if (m->keep_alive_interval_ms == 0 || !cnx) return;
+    uint64_t interval_us = (uint64_t)m->keep_alive_interval_ms * 1000u;
+#if defined(MOQ_PICO_WT_TESTING)
+    if (moq_pico_wt_test_keep_alive)
+        moq_pico_wt_test_keep_alive(cnx, interval_us);
+    else
+        picoquic_enable_keep_alive(cnx, interval_us);
+    moq_pico_wt_test_keep_alive_calls++;
+    moq_pico_wt_test_keep_alive_last_cnx = cnx;
+    moq_pico_wt_test_keep_alive_last_interval_us = interval_us;
+#else
+    picoquic_enable_keep_alive(cnx, interval_us);
+#endif
+}
+
+/* -- Local termination (stop / pump-exit) --------------------------- */
+
+/* Every loop exit goes through here so stop() can tell a loop that is
+ * still flushing from one that is gone (loop_running). Network thread. */
+static int loop_terminate(moq_pico_wt_managed_t *m)
+{
+    pthread_mutex_lock(&m->mutex);
+    m->loop_running = false;
+    pthread_cond_broadcast(&m->cond);
+    pthread_mutex_unlock(&m->mutex);
+    return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+}
+
+/* A stop() or pump-exit while the connection is still open used to end the
+ * packet loop at once, leaving the QUIC connection dangling: nothing was ever
+ * sent, the peer only learned of the departure through its idle timeout
+ * (30 s on red5-moq-relay and moxygen), and a publisher that reconnected
+ * meanwhile could find its namespace still held by the ghost session. Send
+ * CONNECTION_CLOSE and let the loop run its send pass; picoquic moves the
+ * connection to closing once the frame is out. The client cnx is owned by
+ * the application (picoquic never deletes it), so its state can be polled; a
+ * server cnx may be deleted by picoquic once disconnected, so the server side
+ * relies on the bounded deadline instead of dereferencing it again. Returns 0
+ * while the flush is in progress and the terminate code once it is done. */
+static int local_close_step(moq_pico_wt_managed_t *m, picoquic_quic_t *quic)
+{
+    uint64_t now = picoquic_get_quic_time(quic);
+    bool client = m->perspective == MOQ_PERSPECTIVE_CLIENT;
+    if (!m->local_close_started) {
+        m->local_close_started = true;
+        m->local_close_deadline_us = now + MOQ_PICO_WT_LOCAL_CLOSE_FLUSH_US;
+        picoquic_cnx_t *cnx = client ? m->cnx : m->active_cnx;
+        bool peer_closed;
+        pthread_mutex_lock(&m->mutex);
+        peer_closed = m->closed || m->fatal;
+        pthread_mutex_unlock(&m->mutex);
+        if (cnx && !peer_closed &&
+            picoquic_get_cnx_state(cnx) < picoquic_state_disconnecting) {
+            picoquic_close(cnx, 0);
+            return 0;   /* let this cycle's send pass emit the frame */
+        }
+        return loop_terminate(m);   /* nothing to flush */
+    }
+    bool done = now >= m->local_close_deadline_us;
+    if (!done && client && m->cnx)
+        done = picoquic_get_cnx_state(m->cnx) >= picoquic_state_closing_received;
+    return done ? loop_terminate(m) : 0;
 }
 
 /* -- Packet-loop callback (network thread) -------------------------- */
@@ -570,6 +670,7 @@ static int loop_callback(picoquic_quic_t *quic,
         m->network_thread_id = pthread_self();
         m->network_thread_id_set = true;
         m->loop_came_up = true;
+        m->loop_running = true;
         pthread_cond_broadcast(&m->cond);
         pthread_mutex_unlock(&m->mutex);
         if (callback_arg)
@@ -591,6 +692,17 @@ static int loop_callback(picoquic_quic_t *quic,
         return 0;
     }
 
+    /* stop() requested exit (it pipe-woke the loop), or an earlier pump
+     * asked for termination: close the connection on the wire and leave
+     * once the frame is out. Checked before any servicing so the flush
+     * cannot be pre-empted by a fatal/closed path. */
+    bool stop_requested;
+    pthread_mutex_lock(&m->mutex);
+    stop_requested = m->stopped || m->pump_exit;
+    pthread_mutex_unlock(&m->mutex);
+    if (stop_requested)
+        return local_close_step(m, quic);
+
     /* Client connect failure: if the QUIC connection reaches the
      * disconnected state before the WT session is up (handshake
      * timeout, connection refused, cert rejected), surface it as fatal
@@ -610,7 +722,7 @@ static int loop_callback(picoquic_quic_t *quic,
         pthread_mutex_unlock(&m->mutex);
         client_final_pump(m, quic);
         mark_activity(m);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(m);
     }
 
     /* Snapshot conn (set by the WT callback on this same thread). */
@@ -635,7 +747,7 @@ static int loop_callback(picoquic_quic_t *quic,
         pthread_mutex_unlock(&m->mutex);
         client_final_pump(m, quic);
         mark_activity(m);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(m);
     }
 
     if (m->on_pump) {
@@ -645,7 +757,7 @@ static int loop_callback(picoquic_quic_t *quic,
             m->pump_exit = true;
             pthread_mutex_unlock(&m->mutex);
             mark_activity(m);
-            return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+            return local_close_step(m, quic);
         }
     }
 
@@ -658,7 +770,7 @@ static int loop_callback(picoquic_quic_t *quic,
          * it could not have observed it. One final observing pump. */
         client_final_pump(m, quic);
         mark_activity(m);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(m);
     }
 
     /* Cache terminal state for thread-safe accessors. fatal wins over
@@ -684,7 +796,7 @@ static int loop_callback(picoquic_quic_t *quic,
     if (fatal_now) {
         client_final_pump(m, quic);
         mark_activity(m);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(m);
     }
 
     /* Clean close: wait()/wake() are already terminal (m->closed), so a
@@ -713,7 +825,7 @@ static int loop_callback(picoquic_quic_t *quic,
             m->close_flush_saw_inflight = true;  /* non-ACK backlog seen */
         if ((m->close_flush_saw_inflight && backlog_empty) ||
             now >= m->close_flush_deadline_us)
-            return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+            return loop_terminate(m);
         return 0;
     }
 
@@ -907,6 +1019,8 @@ moq_result_t moq_pico_wt_managed_create(
         m->app_deadline_us = cfg->app_deadline_us;
         m->app_deadline_ctx = cfg->app_deadline_ctx;
     }
+    if (CFG_HAS(cfg, keep_alive_interval_ms))
+        m->keep_alive_interval_ms = cfg->keep_alive_interval_ms;
     if (CFG_HAS(cfg, on_activity)) {
         m->on_activity = cfg->on_activity;
         m->on_activity_ctx = cfg->on_activity_ctx;
@@ -1001,6 +1115,10 @@ moq_result_t moq_pico_wt_managed_create(
         picoquic_set_callback(m->cnx, managed_client_h3_callback, m);
         if (picoquic_start_client_cnx(m->cnx) != 0)
             goto fail_configure;
+        /* Keep an otherwise-quiet client connection (a publisher with no
+         * subscriber yet) alive against the peer's idle timeout. No-op
+         * when keep_alive_interval_ms is 0. */
+        pwt_arm_keep_alive(m, m->cnx);
     }
 
     memset(&m->loop_param, 0, sizeof(m->loop_param));
@@ -1089,8 +1207,27 @@ moq_result_t moq_pico_wt_managed_stop(moq_pico_wt_managed_t *m)
         pthread_cond_wait(&m->cond, &m->mutex);
     pthread_mutex_unlock(&m->mutex);
 
-    if (ctx)
+    if (ctx) {
+        /* Pipe-wake the loop so it observes m->stopped, closes a still-open
+         * connection on the wire and exits on its own; wait (bounded) for
+         * that BEFORE picoquic_delete_network_thread, which sets
+         * thread_should_close and would end the loop ahead of the send pass
+         * that carries the CONNECTION_CLOSE. A loop that already exited
+         * (fatal / closed / pump-exit) or never came up has loop_running
+         * clear and is not waited for. */
+        (void)picoquic_wake_up_network_thread(ctx);
+        struct timespec deadline;
+        clock_gettime(CLOCK_REALTIME, &deadline);
+        deadline.tv_sec += 1;
+        pthread_mutex_lock(&m->mutex);
+        while (m->loop_running) {
+            if (pthread_cond_timedwait(&m->cond, &m->mutex,
+                                       &deadline) == ETIMEDOUT)
+                break;
+        }
+        pthread_mutex_unlock(&m->mutex);
         picoquic_delete_network_thread(ctx);
+    }
 
     pthread_mutex_lock(&m->mutex);
     bool was_fatal = m->fatal;

--- a/adapters/pico_wt/tests/test_pico_wt_managed_cfg_abi.c
+++ b/adapters/pico_wt/tests/test_pico_wt_managed_cfg_abi.c
@@ -40,8 +40,12 @@ int main(void)
      * of the allocation. struct_size is stamped to that prefix, so the block is
      * not fully covered and create() must NOT read either field. A gate keyed on
      * app_deadline_us would read cfg->app_deadline_ctx past the allocation. */
-    size_t prefix = offsetof(moq_pico_wt_managed_cfg_t, app_deadline_us) +
-                    sizeof(((moq_pico_wt_managed_cfg_t *)0)->app_deadline_us);
+    /* volatile: the allocation is deliberately shorter than the struct, and a
+     * constant-folded size lets GCC's -Warray-bounds reject the field writes
+     * below as "partly outside array bounds" (-Werror) even though every write
+     * stays inside the prefix. */
+    volatile size_t prefix = offsetof(moq_pico_wt_managed_cfg_t, app_deadline_us) +
+                             sizeof(((moq_pico_wt_managed_cfg_t *)0)->app_deadline_us);
     unsigned char *raw = (unsigned char *)malloc(prefix);
     if (!raw) return 4;
     memset(raw, 0, prefix);

--- a/adapters/pico_wt/tests/test_pico_wt_managed_keepalive.c
+++ b/adapters/pico_wt/tests/test_pico_wt_managed_keepalive.c
@@ -1,0 +1,127 @@
+/*
+ * Deterministic proof that the managed pico WT facade arms QUIC keepalive from
+ * moq_pico_wt_managed_cfg_t.keep_alive_interval_ms. Same shape as the raw
+ * threaded adapter's test_threaded_keepalive: no live handshake, no relay, no
+ * 30 s wall clock -- the arming call is routed through the MOQ_PICO_WT_TESTING
+ * seam, a client create is driven, and the seam records the call count, the
+ * connection and the converted microsecond interval.
+ *
+ * Why it matters: a WebTransport publisher waiting for its first subscriber
+ * sends nothing, and red5-moq-relay / moxygen idle a silent session out after
+ * 30 s; the raw picoquic facade already armed keepalive, the WT one did not.
+ *
+ * Recompiles the managed sources with MOQ_PICO_WT_TESTING (never shipped).
+ */
+#include <moq/moq.h>
+#include <moq/pico_wt_managed.h>
+
+#include <picoquic.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The MOQ_PICO_WT_TESTING keepalive seam (deliberately NOT public). */
+extern void (*moq_pico_wt_test_keep_alive)(picoquic_cnx_t *, uint64_t);
+extern unsigned moq_pico_wt_test_keep_alive_calls;
+extern picoquic_cnx_t *moq_pico_wt_test_keep_alive_last_cnx;
+extern uint64_t moq_pico_wt_test_keep_alive_last_interval_us;
+
+static int failures = 0;
+#define CHECK(expr) do { if (!(expr)) { \
+    fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    failures++; } } while (0)
+
+/* Recorder hook: capture only, so the real picoquic_enable_keep_alive is not
+ * invoked on the test connection. */
+static void ka_noop(picoquic_cnx_t *cnx, uint64_t interval_us)
+{
+    (void)cnx; (void)interval_us;
+}
+
+static int stub_pump(moq_pico_wt_managed_t *m, uint64_t now, void *ctx)
+{ (void)m; (void)now; (void)ctx; return 0; }
+
+/* Minimal CLIENT config that creates a real client cnx without a relay:
+ * 127.0.0.1 resolves offline, nothing listens on the port, the network thread
+ * never connects, and stop/destroy tear it down. */
+static void client_cfg(moq_pico_wt_managed_cfg_t *cfg, size_t size)
+{
+    moq_pico_wt_managed_cfg_init_sized(cfg, size);
+    cfg->alloc = moq_alloc_default();
+    cfg->perspective = MOQ_PERSPECTIVE_CLIENT;
+    cfg->host = "127.0.0.1";
+    cfg->port = 34567;
+    cfg->insecure_skip_verify = true;
+    cfg->on_pump = stub_pump;
+}
+
+static void reset_seam(void)
+{
+    moq_pico_wt_test_keep_alive = ka_noop;
+    moq_pico_wt_test_keep_alive_calls = 0;
+    moq_pico_wt_test_keep_alive_last_cnx = NULL;
+    moq_pico_wt_test_keep_alive_last_interval_us = 0;
+}
+
+/* keep_alive_interval_ms = 1234 -> exactly one call, non-NULL cnx, 1234000 us. */
+static void test_client_opt_in(void)
+{
+    reset_seam();
+    moq_pico_wt_managed_cfg_t cfg;
+    client_cfg(&cfg, sizeof(cfg));
+    cfg.keep_alive_interval_ms = 1234;
+
+    moq_pico_wt_managed_t *m = NULL;
+    moq_result_t rc = moq_pico_wt_managed_create(&cfg, &m);
+    CHECK(rc == MOQ_OK);
+    CHECK(moq_pico_wt_test_keep_alive_calls == 1);
+    CHECK(moq_pico_wt_test_keep_alive_last_cnx != NULL);
+    CHECK(moq_pico_wt_test_keep_alive_last_interval_us == 1234000ull);
+    if (m) { moq_pico_wt_managed_stop(m); moq_pico_wt_managed_destroy(m); }
+}
+
+/* Default (0) -> keepalive is never armed. */
+static void test_client_default_off(void)
+{
+    reset_seam();
+    moq_pico_wt_managed_cfg_t cfg;
+    client_cfg(&cfg, sizeof(cfg));
+
+    moq_pico_wt_managed_t *m = NULL;
+    moq_result_t rc = moq_pico_wt_managed_create(&cfg, &m);
+    CHECK(rc == MOQ_OK);
+    CHECK(moq_pico_wt_test_keep_alive_calls == 0);
+    if (m) { moq_pico_wt_managed_stop(m); moq_pico_wt_managed_destroy(m); }
+}
+
+/* ABI: a caller whose struct_size predates the field never has it read, even
+ * with a nonzero value sitting in the (to it, trailing) memory. */
+static void test_short_struct_size_ignores_field(void)
+{
+    reset_seam();
+    moq_pico_wt_managed_cfg_t cfg;
+    client_cfg(&cfg, offsetof(moq_pico_wt_managed_cfg_t, keep_alive_interval_ms));
+    cfg.keep_alive_interval_ms = 1234;   /* beyond the declared size */
+
+    moq_pico_wt_managed_t *m = NULL;
+    moq_result_t rc = moq_pico_wt_managed_create(&cfg, &m);
+    CHECK(rc == MOQ_OK);
+    CHECK(moq_pico_wt_test_keep_alive_calls == 0);
+    if (m) { moq_pico_wt_managed_stop(m); moq_pico_wt_managed_destroy(m); }
+}
+
+int main(void)
+{
+    test_client_opt_in();
+    test_client_default_off();
+    test_short_struct_size_ignores_field();
+    if (failures) {
+        fprintf(stderr, "%d failure(s)\n", failures);
+        return 1;
+    }
+    puts("pico_wt managed keepalive: OK");
+    return 0;
+}

--- a/adapters/pico_wt/tests/test_pico_wt_managed_loopback.c
+++ b/adapters/pico_wt/tests/test_pico_wt_managed_loopback.c
@@ -219,6 +219,9 @@ typedef struct {
     int        do_done;
     int        done_sent;
     int        done_rc;          /* moq_session_publish_namespace_done() result */
+    /* stop_close mode: keep pumping after the object (no GOAWAY, no
+     * pump-exit) so the test can stop() a facade whose connection is open. */
+    int        keep_running;
 } client_app_t;
 
 static void client_subscribe(moq_session_t *s, client_app_t *a)
@@ -315,7 +318,7 @@ static int client_pump(moq_pico_wt_managed_t *m, uint64_t now, void *ctx)
         }
         moq_event_cleanup(&ev);
     }
-    if (a->initiate_goaway)
+    if (a->initiate_goaway || a->keep_running)
         return 0;  /* keep running to reach the terminal closed state */
     return atomic_load(&a->got_object) ? 1 : 0;  /* else pump-exit */
 }
@@ -538,6 +541,82 @@ static run_status_t run_loopback_proto(const char *cert, const char *key,
         return RUN_HARD;                  /* real handshake/object failure */
     }
     fprintf(stderr, "[loopback] port %d: no setup reached "
+            "(retryable; port may be busy)\n", port);
+    return RUN_RETRY;
+}
+
+/* stop() closes an open connection on the wire. After the object the client
+ * keeps pumping (no GOAWAY, no pump-exit) and the test stops it while its
+ * connection is up. The server must learn of the departure promptly -- from
+ * the client's CONNECTION_CLOSE, not from its own idle timeout -- so its
+ * facade reaches the closed state within a couple of seconds, and never
+ * fatal. Before the fix stop() only joined the network thread: nothing was
+ * sent and a relay held the ghost session (and the namespace it announced)
+ * until the 30 s idle timeout. */
+static run_status_t run_stop_close(const char *cert, const char *key,
+                                   int port, int timeout_sec)
+{
+    server_app_t sapp; memset(&sapp, 0, sizeof(sapp));
+    moq_pico_wt_managed_t *srv = make_server(cert, key, port, &sapp);
+    if (!srv) return RUN_RETRY;
+    for (int i = 0; i < 3; i++) moq_pico_wt_managed_wait(srv, 100000);
+
+    client_app_t capp; memset(&capp, 0, sizeof(capp));
+    atomic_init(&capp.got_object, 0);
+    capp.keep_running = 1;
+    moq_pico_wt_managed_t *cli =
+        make_client(moq_pico_wt_managed_local_port(srv), &capp);
+    if (!cli) {
+        moq_pico_wt_managed_stop(srv);
+        moq_pico_wt_managed_destroy(srv);
+        return RUN_RETRY;
+    }
+
+    wait_for_object(cli, &capp, timeout_sec);
+    int got = atomic_load(&capp.got_object);
+    int cli_fatal = moq_pico_wt_managed_is_fatal(cli);
+
+    /* The connection is open and idle: stop() must close it on the wire. */
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    moq_pico_wt_managed_stop(cli);
+    int reached_setup = capp.subscribed;
+
+    int srv_closed = 0;
+    double waited_s = 0.0;
+    if (got) {
+        for (;;) {
+            if (moq_pico_wt_managed_is_closed(srv)) { srv_closed = 1; break; }
+            moq_pico_wt_managed_wait(srv, 100000);
+            struct timespec t1;
+            clock_gettime(CLOCK_MONOTONIC, &t1);
+            waited_s = (double)(t1.tv_sec - t0.tv_sec) +
+                       (double)(t1.tv_nsec - t0.tv_nsec) / 1e9;
+            if (waited_s >= 3.0) break;
+        }
+    }
+    int srv_fatal = moq_pico_wt_managed_is_fatal(srv);
+
+    moq_pico_wt_managed_destroy(cli);
+    moq_pico_wt_managed_stop(srv);
+    moq_pico_wt_managed_destroy(srv);
+
+    if (got) {
+        CHECK(!cli_fatal);
+        if (!srv_closed)
+            fprintf(stderr, "[stop_close] server did not observe the client's "
+                            "close within %.1fs (idle timeout instead?)\n",
+                    waited_s);
+        CHECK(srv_closed);
+        CHECK(!srv_fatal);
+        return RUN_OK;
+    }
+    if (reached_setup || cli_fatal) {
+        fprintf(stderr, "[stop_close] port %d HARD FAIL: setup=%d fatal=%d "
+                        "got=0\n", port, reached_setup, cli_fatal);
+        return RUN_HARD;
+    }
+    fprintf(stderr, "[stop_close] port %d: no setup reached "
             "(retryable; port may be busy)\n", port);
     return RUN_RETRY;
 }
@@ -1453,16 +1532,17 @@ int main(int argc, char **argv)
     int announce_done_no_rsa = !strcmp(mode, "announce_done_no_rsa");
     int loopback_18 = !strcmp(mode, "loopback_18");
     int alpn_close_18 = !strcmp(mode, "alpn_close_18");
+    int stop_close = !strcmp(mode, "stop_close");
     if (!refuse && !close_mode && !nego && !nego_refuse && !nego_legacy &&
         !nego_legacy_18 && !no_rsa && !bigobj && !bigobj_smallwin &&
         !bigobj_drain && !announce && !announce_18 && !announce_done_18 &&
         !announce_done_no_rsa && !loopback_18 && !alpn_close_18 &&
-        strcmp(mode, "loopback") != 0) {
+        !stop_close && strcmp(mode, "loopback") != 0) {
         fprintf(stderr, "unknown --mode '%s' (expected loopback|refuse|close|"
                 "nego|nego_refuse|nego_legacy|nego_legacy_18|"
                 "no_reset_stream_at|bigobj|bigobj_smallwin|bigobj_drain|"
                 "announce|announce_18|announce_done_18|announce_done_no_rsa|"
-                "loopback_18|alpn_close_18)\n", mode);
+                "loopback_18|alpn_close_18|stop_close)\n", mode);
         return 2;
     }
 
@@ -1481,6 +1561,7 @@ int main(int argc, char **argv)
     run_status_t st = RUN_RETRY;
     for (size_t i = 0; i < sizeof(ports) / sizeof(ports[0]); i++) {
         st = refuse         ? run_refuse(cert, key, ports[i], 6)
+           : stop_close     ? run_stop_close(cert, key, ports[i], 6)
            : close_mode     ? run_close(cert, key, ports[i], 6)
            : nego           ? run_nego(cert, key, ports[i], 6)
            : nego_refuse    ? run_nego_refuse(cert, key, ports[i], 6)

--- a/adapters/picoquic/CMakeLists.txt
+++ b/adapters/picoquic/CMakeLists.txt
@@ -493,6 +493,20 @@ if(MOQ_BUILD_TESTS AND MOQ_BUILD_PQ_THREADED)
         "${MOQ_PICOQUIC_SOURCE_DIR}/picoquic")
     add_test(NAME threaded_keepalive COMMAND test_threaded_keepalive)
 
+    # stop() on a facade whose connection is open must send CONNECTION_CLOSE
+    # before joining the thread: a loopback threaded server sees its
+    # connection count drop within seconds of the client's stop(), not after
+    # the idle timeout. Real handshake over loopback (needs the test cert).
+    add_executable(test_threaded_stop_close tests/test_threaded_stop_close.c)
+    target_link_libraries(test_threaded_stop_close PRIVATE
+        moq-adapter-picoquic-threaded-test-internals)
+    target_compile_definitions(test_threaded_stop_close PRIVATE
+        MOQ_TEST_CERT_PATH="${_pq_tls_cert}"
+        MOQ_TEST_KEY_PATH="${_pq_tls_key}")
+    add_test(NAME threaded_stop_close COMMAND test_threaded_stop_close)
+    set_tests_properties(threaded_stop_close PROPERTIES
+        TIMEOUT 60 SKIP_RETURN_CODE 77)
+
     set(_threaded_consumer_src "${CMAKE_CURRENT_SOURCE_DIR}/tests/consumer-threaded")
     set(_threaded_consumer_bld "${CMAKE_CURRENT_BINARY_DIR}/consumer-threaded-test-build")
     add_test(NAME adapter_threaded_consumer

--- a/adapters/picoquic/include/moq/picoquic_threaded.h
+++ b/adapters/picoquic/include/moq/picoquic_threaded.h
@@ -320,6 +320,14 @@ moq_result_t moq_pq_threaded_create(const moq_pq_threaded_cfg_t *cfg,
  * MUST NOT be called from on_lane_pump or on_activity; returns
  * MOQ_ERR_WRONG_STATE if detected.
  *
+ * Connections still open when stop() is called are closed on the wire
+ * first: the loop sends CONNECTION_CLOSE (application code 0) on each and
+ * is given a short bounded window (MOQ_PQ_THREADED_LOCAL_CLOSE_FLUSH_US) to
+ * put it on the wire before the thread is joined, so the peer sees a
+ * prompt close instead of an idle timeout. The same applies when
+ * on_lane_pump requests termination. Stopping does not wait for the
+ * peer's reply.
+ *
  * After return, no more callbacks will fire. The caller must then
  * destroy its facade (if any) and call _destroy().
  */

--- a/adapters/picoquic/moq_picoquic_threaded.c
+++ b/adapters/picoquic/moq_picoquic_threaded.c
@@ -148,6 +148,12 @@ struct moq_pq_threaded {
                                          * done (no queued/ready stream data or
                                          * unsent FIN). Read by drain_state. */
     bool                loop_exited;    /* loop acknowledged stop request */
+    bool                loop_running;   /* between the ready callback and the
+                                         * loop's own termination; stop() waits
+                                         * (bounded) for it to clear so a queued
+                                         * CONNECTION_CLOSE reaches the wire */
+    bool                local_close_started;      /* network thread only */
+    uint64_t            local_close_deadline_us;  /* network thread only */
     bool                loop_came_up;   /* packet loop reached its ready
                                            callback (latched; a later loop
                                            exit does not clear it) */
@@ -785,6 +791,73 @@ static uint64_t pq_sum_pkts_sent(moq_pq_threaded_t *t)
     return sum;
 }
 
+/* Bounded window a local stop/pump-exit gives the packet loop to put the
+ * CONNECTION_CLOSE on the wire before the network thread is joined. */
+#ifndef MOQ_PQ_THREADED_LOCAL_CLOSE_FLUSH_US
+#define MOQ_PQ_THREADED_LOCAL_CLOSE_FLUSH_US 250000u
+#endif
+
+/* Every loop exit goes through here so stop() can tell a loop that is
+ * still flushing from one that is gone (loop_running). Network thread. */
+static int loop_terminate(moq_pq_threaded_t *t)
+{
+    pthread_mutex_lock(&t->mutex);
+    t->loop_running = false;
+    t->loop_exited = true;
+    pthread_cond_broadcast(&t->cond);
+    pthread_mutex_unlock(&t->mutex);
+    return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+}
+
+/* A stop() or pump-exit while a connection is still open used to end the
+ * packet loop at once, leaving the QUIC connection dangling: nothing was ever
+ * sent, the peer only learned of the departure through its idle timeout
+ * (30 s on red5-moq-relay and moxygen), and a publisher that reconnected
+ * meanwhile could find its namespace still held by the ghost session. Send
+ * CONNECTION_CLOSE on every open connection and let the loop run its send
+ * pass; picoquic moves a connection to closing once the frame is out. The
+ * client cnx is owned by the application (picoquic never deletes it), so its
+ * state can be polled; a server cnx may be deleted by picoquic once
+ * disconnected (the record's pointer is cleared by server_conn_after_callback),
+ * so the server side relies on the bounded deadline instead. Returns 0 while
+ * the flush is in progress and the terminate code once it is done. */
+static int local_close_step(moq_pq_threaded_t *t, picoquic_quic_t *quic)
+{
+    uint64_t now = picoquic_get_quic_time(quic);
+    bool client = t->perspective == MOQ_PERSPECTIVE_CLIENT;
+    if (!t->local_close_started) {
+        t->local_close_started = true;
+        t->local_close_deadline_us = now + MOQ_PQ_THREADED_LOCAL_CLOSE_FLUSH_US;
+        bool sent = false;
+        if (client) {
+            bool peer_gone;
+            pthread_mutex_lock(&t->mutex);
+            peer_gone = t->fatal;
+            pthread_mutex_unlock(&t->mutex);
+            if (t->active_cnx && !peer_gone &&
+                picoquic_get_cnx_state(t->active_cnx) < picoquic_state_disconnecting) {
+                picoquic_close(t->active_cnx, 0);
+                sent = true;
+            }
+        } else {
+            for (size_t i = 0; i < t->conn_count; i++) {
+                picoquic_cnx_t *cnx = t->conns[i]->cnx;
+                if (cnx && picoquic_get_cnx_state(cnx) < picoquic_state_disconnecting) {
+                    picoquic_close(cnx, 0);
+                    sent = true;
+                }
+            }
+        }
+        if (sent)
+            return 0;   /* let this cycle's send pass emit the frame(s) */
+        return loop_terminate(t);   /* nothing to flush */
+    }
+    bool done = now >= t->local_close_deadline_us;
+    if (!done && client && t->active_cnx)
+        done = picoquic_get_cnx_state(t->active_cnx) >= picoquic_state_closing_received;
+    return done ? loop_terminate(t) : 0;
+}
+
 static int loop_callback(picoquic_quic_t *quic,
     picoquic_packet_loop_cb_enum cb_mode,
     void *callback_ctx, void *callback_arg)
@@ -796,6 +869,7 @@ static int loop_callback(picoquic_quic_t *quic,
         t->network_thread_id = pthread_self();
         t->network_thread_id_set = true;
         t->loop_came_up = true;
+        t->loop_running = true;
         pthread_cond_broadcast(&t->cond);
         pthread_mutex_unlock(&t->mutex);
         return 0;
@@ -843,14 +917,10 @@ static int loop_callback(picoquic_quic_t *quic,
      * reliably interrupt a blocked wait on every platform, so without
      * this the join would stall until the loop's natural timer. */
     pthread_mutex_lock(&t->mutex);
-    bool stop_requested = t->stopped;
-    if (stop_requested) {
-        t->loop_exited = true;
-        pthread_cond_broadcast(&t->cond);
-    }
+    bool stop_requested = t->stopped || t->pump_exit;
     pthread_mutex_unlock(&t->mutex);
     if (stop_requested)
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return local_close_step(t, quic);   /* close on the wire, then leave */
 
     /* Client mode (deferred-offer): before the session exists, the only
      * terminal signal is the connection dying (e.g. ALPN no-overlap ends the
@@ -868,7 +938,7 @@ static int loop_callback(picoquic_quic_t *quic,
         pthread_mutex_unlock(&t->mutex);
         client_final_pump(t, quic);
         mark_activity(t);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(t);
     }
 
     /* --- SERVER: service every connection, one on_lane_pump, then prune. A
@@ -895,7 +965,7 @@ static int loop_callback(picoquic_quic_t *quic,
                 t->pump_exit = true;
                 pthread_mutex_unlock(&t->mutex);
                 mark_activity(t);
-                return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+                return local_close_step(t, quic);
             }
         }
         /* Every conn dead before/during that pump was observable by it. */
@@ -923,7 +993,7 @@ static int loop_callback(picoquic_quic_t *quic,
                 t->pump_exit = true;
                 pthread_mutex_unlock(&t->mutex);
                 mark_activity(t);
-                return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+                return local_close_step(t, quic);
             }
             server_mark_dead_observed(t);
         }
@@ -1000,7 +1070,7 @@ static int loop_callback(picoquic_quic_t *quic,
             pthread_mutex_unlock(&t->mutex);
             client_final_pump(t, quic);
             mark_activity(t);
-            return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+            return loop_terminate(t);
         }
     }
 
@@ -1012,7 +1082,7 @@ static int loop_callback(picoquic_quic_t *quic,
         pthread_mutex_unlock(&t->mutex);
         client_final_pump(t, quic);
         mark_activity(t);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(t);
     }
 
     if (t->on_lane_pump) {
@@ -1024,7 +1094,7 @@ static int loop_callback(picoquic_quic_t *quic,
             t->pump_exit = true;
             pthread_mutex_unlock(&t->mutex);
             mark_activity(t);
-            return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+            return local_close_step(t, quic);
         }
     }
 
@@ -1037,7 +1107,7 @@ static int loop_callback(picoquic_quic_t *quic,
          * it could not have observed it. One final observing pump. */
         client_final_pump(t, quic);
         mark_activity(t);
-        return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+        return loop_terminate(t);
     }
 
     /* Set app wake time for session deadlines. */
@@ -1563,7 +1633,11 @@ moq_result_t moq_pq_threaded_stop(moq_pq_threaded_t *t)
         clock_gettime(CLOCK_REALTIME, &deadline);
         deadline.tv_sec += 3;
         pthread_mutex_lock(&t->mutex);
-        while (!t->loop_exited && !t->fatal && !t->pump_exit) {
+        /* loop_running clears when the loop leaves on its own -- after the
+         * close flush on a stop, or on a fatal / pump-exit / clean close
+         * that already ended it -- and is never set for a loop that never
+         * came up. */
+        while (t->loop_running) {
             if (pthread_cond_timedwait(&t->cond, &t->mutex,
                                        &deadline) == ETIMEDOUT)
                 break;

--- a/adapters/picoquic/tests/test_threaded_stop_close.c
+++ b/adapters/picoquic/tests/test_threaded_stop_close.c
@@ -1,0 +1,168 @@
+/*
+ * stop() closes an open connection on the wire (raw picoquic facade).
+ *
+ * A managed threaded SERVER and a managed threaded CLIENT talk over loopback.
+ * Once the client session is ESTABLISHED and idle, the test stops the client.
+ * The server must learn of the departure promptly -- from the client's
+ * CONNECTION_CLOSE, not from its own idle timeout -- so its connection count
+ * drops to zero within a couple of seconds. Before the fix stop() only joined
+ * the network thread: nothing was sent, and a relay kept the ghost session
+ * (and the namespace it announced) until the 30 s idle timeout, which is
+ * exactly what red5-moq-relay logged for every libmoq publisher exit.
+ */
+#include <moq/picoquic_threaded.h>
+#include <moq/types.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+#define CHECK(expr)                                                     \
+    do {                                                                \
+        if (!(expr)) {                                                  \
+            fprintf(stderr, "FAIL: %s:%d: %s\n",                        \
+                    __FILE__, __LINE__, #expr);                         \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+#ifdef MOQ_TEST_CERT_PATH
+
+static int server_pump(moq_pq_threaded_t *t, moq_pq_threaded_lane_t *lane,
+                       uint64_t now, void *u)
+{
+    (void)t; (void)lane; (void)now; (void)u;
+    return 0;
+}
+
+typedef struct {
+    int established;   /* atomic: set when the client session reaches ESTABLISHED */
+} cli_ctx_t;
+
+static int client_pump(moq_pq_threaded_t *t, moq_pq_threaded_lane_t *lane,
+                       uint64_t now, void *u)
+{
+    (void)lane; (void)now;
+    cli_ctx_t *c = (cli_ctx_t *)u;
+    moq_session_t *s = moq_pq_threaded_session(t);
+    if (s && moq_session_state(s) == MOQ_SESS_ESTABLISHED)
+        __atomic_store_n(&c->established, 1, __ATOMIC_RELEASE);
+    return 0;   /* keep running: the test stops the facade itself */
+}
+
+static double elapsed_s(const struct timespec *t0)
+{
+    struct timespec t1;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    return (double)(t1.tv_sec - t0->tv_sec) +
+           (double)(t1.tv_nsec - t0->tv_nsec) / 1e9;
+}
+
+/* 1 = ran to a verdict, 0 = the client never established (port busy /
+ * handshake stalled: retry on another port). */
+static int run_once(int port)
+{
+    moq_pq_threaded_cfg_t srv_cfg;
+    moq_pq_threaded_cfg_init_sized(&srv_cfg, sizeof(srv_cfg));
+    srv_cfg.alloc = moq_alloc_default();
+    srv_cfg.perspective = MOQ_PERSPECTIVE_SERVER;
+    srv_cfg.cert_path = MOQ_TEST_CERT_PATH;
+    srv_cfg.key_path = MOQ_TEST_KEY_PATH;
+    srv_cfg.port = port;
+    srv_cfg.on_lane_pump = server_pump;
+    moq_pq_threaded_t *srv = NULL;
+    if (moq_pq_threaded_create(&srv_cfg, &srv) != MOQ_OK || !srv)
+        return 0;
+    for (int i = 0; i < 3; i++) moq_pq_threaded_wait(srv, 100000);
+
+    cli_ctx_t cc; memset(&cc, 0, sizeof(cc));
+    moq_pq_threaded_cfg_t cli_cfg;
+    moq_pq_threaded_cfg_init_sized(&cli_cfg, sizeof(cli_cfg));
+    cli_cfg.alloc = moq_alloc_default();
+    cli_cfg.perspective = MOQ_PERSPECTIVE_CLIENT;
+    cli_cfg.host = "127.0.0.1";
+    cli_cfg.port = port;
+    cli_cfg.insecure_skip_verify = true;
+    cli_cfg.on_lane_pump = client_pump;
+    cli_cfg.on_lane_pump_ctx = &cc;
+    moq_pq_threaded_t *cli = NULL;
+    if (moq_pq_threaded_create(&cli_cfg, &cli) != MOQ_OK || !cli) {
+        moq_pq_threaded_stop(srv);
+        moq_pq_threaded_destroy(srv);
+        return 0;
+    }
+
+    int established = 0;
+    for (int i = 0; i < 400 && !established; i++) {
+        established = __atomic_load_n(&cc.established, __ATOMIC_ACQUIRE);
+        if (!established) moq_pq_threaded_wait(cli, 25000);
+    }
+    if (!established) {
+        moq_pq_threaded_stop(cli);
+        moq_pq_threaded_destroy(cli);
+        moq_pq_threaded_stop(srv);
+        moq_pq_threaded_destroy(srv);
+        return 0;
+    }
+    /* Let the server see the established session as a live connection. */
+    for (int i = 0; i < 20 && moq_pq_threaded_conn_count(srv) == 0; i++)
+        moq_pq_threaded_wait(srv, 50000);
+    CHECK(moq_pq_threaded_conn_count(srv) == 1);
+
+    /* The connection is open and idle: stop() must close it on the wire. */
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    moq_pq_threaded_stop(cli);
+    double stop_s = elapsed_s(&t0);
+    CHECK(stop_s < 2.0);   /* the close flush is bounded, not a full join stall */
+
+    int gone = 0;
+    while (elapsed_s(&t0) < 3.0) {
+        if (moq_pq_threaded_conn_count(srv) == 0) { gone = 1; break; }
+        moq_pq_threaded_wait(srv, 100000);
+    }
+    if (!gone)
+        fprintf(stderr, "[stop_close] server still holds the connection %.1fs "
+                        "after the client stopped (idle timeout instead of "
+                        "CONNECTION_CLOSE?)\n", elapsed_s(&t0));
+    CHECK(gone);
+    CHECK(!moq_pq_threaded_is_fatal(srv));
+
+    moq_pq_threaded_destroy(cli);
+    moq_pq_threaded_stop(srv);
+    moq_pq_threaded_destroy(srv);
+    return 1;
+}
+
+int main(void)
+{
+    srand((unsigned)getpid());
+    int decided = 0;
+    for (int attempt = 0; attempt < 4 && !decided; attempt++) {
+        int port = 16300 + (rand() % 300);
+        decided = run_once(port);
+    }
+    if (!decided) {
+        fprintf(stderr, "no attempt reached an established session; skipping\n");
+        return 77;
+    }
+    if (failures) {
+        fprintf(stderr, "%d failure(s)\n", failures);
+        return 1;
+    }
+    puts("threaded stop close: OK");
+    return 0;
+}
+
+#else
+int main(void)
+{
+    fprintf(stderr, "MOQ_TEST_CERT_PATH not defined; skipping\n");
+    return 77;
+}
+#endif

--- a/service/src/endpoint.c
+++ b/service/src/endpoint.c
@@ -1216,6 +1216,10 @@ static moq_result_t ep_create_wt(moq_endpoint_t *ep,
     fc.wt_protocols = ep->wt_offer;
     fc.configure_quic = ep_configure_quic;
     fc.configure_quic_ctx = ep;
+    /* Same keepalive as the raw picoquic facade: a publisher waiting for its
+     * first subscriber sends nothing, and red5-moq-relay / moxygen idle a
+     * silent WebTransport session out after 30 s. */
+    fc.keep_alive_interval_ms = 15000;
     fc.on_pump = ep_wt_pump;
     fc.on_pump_ctx = ep;
     moq_pico_wt_managed_t *fac = NULL;


### PR DESCRIPTION
Closes #17, closes #18.

Found by publishing from moqxr's libmoq backend (`-DOPENMOQ_USE_LIBMOQ_PUBLISHER=ON`, local moq5 `main` at `0cb6ecf`) to red5-moq-relay 1.6.44 at `moq-relay.red5.net:4433` on draft-16 over WebTransport and raw QUIC.

## What changed

**Close on the wire before the thread is joined (#17).** Both `moq_pq_threaded_stop()` and `moq_pico_wt_managed_stop()` used to set the stop flag and join; the loop returned TERMINATE at once and the relay logged every libmoq exit as `Idle timeout ... (1075)` 30 s later, holding the ghost session and its namespace meanwhile. Now the loop callback, on a stop or an `on_pump` termination request, calls `picoquic_close(cnx, 0)` on each open connection and keeps its send pass running until picoquic reports the frame out (`state >= closing_received` on the application-owned client cnx) or a 250 ms window elapses (`MOQ_PQ_THREADED_LOCAL_CLOSE_FLUSH_US` / `MOQ_PICO_WT_LOCAL_CLOSE_FLUSH_US`). `stop()` pipe-wakes the loop and waits (bounded) for a new `loop_running` flag to clear before `picoquic_delete_network_thread`, which sets `thread_should_close` and would otherwise end the loop ahead of that send pass. A server cnx may be deleted by picoquic once disconnected, so the server side relies on the deadline instead of polling it. Every loop exit goes through `loop_terminate()` so the wait also sees a loop that already left on its own (fatal, clean close, pump-exit) or never came up.

**Keepalive on the managed WT facade (#18).** Appended `keep_alive_interval_ms` to `moq_pico_wt_managed_cfg_t` (struct_size gated), armed on the client connection after `picoquic_start_client_cnx` and on each accepted server connection, mirroring `moq_pq_threaded_cfg_t`. `moq_endpoint_connect` sets 15 s for the WT facade as it already did for raw QUIC.

**GCC build of the managed tests.** `test_pico_wt_managed_cfg_abi` deliberately allocates a short prefix of the cfg struct; GCC 13's `-Warray-bounds` rejected its in-bounds field writes under `-Werror` (CI builds with clang and never hit it). A `volatile` size keeps the test's intent.

## Tests

- `threaded_stop_close` (new): loopback threaded server + client; the server's connection count must drop within 3 s of the client's `stop()`.
- `pico_wt_managed_loopback --mode stop_close` (new mode): the server facade must reach closed, not fatal, within 3 s of the client's `stop()`.
- `pico_wt_managed_keepalive` (new): the `MOQ_PICO_WT_TESTING` seam proves one arming call with the converted interval, none by default, none for a struct_size that predates the field.

Both stop-close tests fail on `main` (built in a worktree with only the tests added) and pass here. Full `ctest` on this tree: 215 of 220 pass; the five failures (`pico_wt_d18`, `pico_wt_rx_lifecycle`, `media_receiver`, the two `pkgconfig_consumer` tests) fail identically on unpatched `main` in the same environment.

## Against the relay

With moqxr rebuilt on this branch, the same publisher runs now end with `WebTransport session 18 close cause: code=0, Peer closed the connection (no error code)` and `Session 19 closed: error=0` (raw) at the moment the process exits, instead of 1075 thirty seconds later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/19)
<!-- Reviewable:end -->
