### PR TITLE
mvfst adapter interop: current fizz/folly, QUIC v1, out-of-order request IDs, session lifetime

### DIFF
--- a/adapters/mvfst/CMakeLists.txt
+++ b/adapters/mvfst/CMakeLists.txt
@@ -34,14 +34,17 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # -- Resolve mvfst --------------------------------------------------
 
-find_package(mvfst CONFIG REQUIRED)
-
-# mvfst's static folly/mvfst archives carry unresolved fmt references
-# (libfolly.a(json.cpp.o), libmvfst.a(QuicException.cpp.o)). fmt::fmt must be
-# in the adapter's exported link interface so a consumer naming only
+# fmt BEFORE mvfst: folly's package config references fmt::fmt but does not
+# find it itself, so find_package(mvfst) -> find_dependency(folly) fails with
+# "imported targets are referenced, but are missing: fmt::fmt" unless the
+# target already exists (seen with a moxygen getdeps-built prefix).
+# mvfst's static folly/mvfst archives also carry unresolved fmt references
+# (libfolly.a(json.cpp.o), libmvfst.a(QuicException.cpp.o)), so fmt::fmt must
+# be in the adapter's exported link interface: a consumer naming only
 # moq::adapter-mvfst links without adding fmt directly -- it cannot rely on
 # Folly's package config happening to discover fmt on the consumer side.
 find_package(fmt CONFIG REQUIRED)
+find_package(mvfst CONFIG REQUIRED)
 
 # -- Adapter library ------------------------------------------------
 

--- a/adapters/mvfst/include/moq/mvfst.h
+++ b/adapters/mvfst/include/moq/mvfst.h
@@ -264,8 +264,10 @@ MOQ_API moq_result_t moq_mvfst_managed_create(
 
 /*
  * Request clean shutdown. Idempotent. Joins the network thread.
- * After stop returns, no callbacks will fire and the session is
- * destroyed.
+ * After stop returns, no callbacks will fire. The client session stays
+ * allocated (but no longer serviced) until _destroy(), like the picoquic
+ * facades, so a service-tier consumer that still holds it can tear down
+ * after the endpoint went terminal.
  *
  * Must NOT be called from on_lane_pump or on_activity.
  * Returns MOQ_ERR_INVAL if called from the managed thread.

--- a/adapters/mvfst/src/mvfst_adapter.cpp
+++ b/adapters/mvfst/src/mvfst_adapter.cpp
@@ -47,6 +47,43 @@
 #include <quic/server/QuicServerTransport.h>
 #include <fizz/backend/openssl/certificate/CertUtils.h>
 #include <fizz/backend/openssl/certificate/OpenSSLCertificateVerifier.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace {
+/* fizz's OpenSSLCertificateVerifier grew a static create() factory and made
+ * its constructors protected (they now also take the CertificateAuthorities
+ * advertised in the handshake). fizz carries no version macro, so detect the
+ * factory and fall back to the public constructors of older releases. A null
+ * store selects system trust in both APIs. */
+template <typename V, typename = void>
+struct has_verifier_create : std::false_type {};
+template <typename V>
+struct has_verifier_create<V, std::void_t<decltype(V::create(
+    std::declval<std::unique_ptr<V> &>(), std::declval<fizz::Error &>(),
+    std::declval<fizz::VerificationContext>(),
+    std::declval<folly::ssl::X509StoreUniquePtr &&>()))>>
+    : std::true_type {};
+
+template <typename V = fizz::openssl::OpenSSLCertificateVerifier>
+std::shared_ptr<V> make_chain_verifier(folly::ssl::X509StoreUniquePtr store)
+{
+    if constexpr (has_verifier_create<V>::value) {
+        std::unique_ptr<V> ret;
+        fizz::Error err;
+        if (V::create(ret, err, fizz::VerificationContext::Client,
+                      std::move(store)) != fizz::Status::Success || !ret)
+            throw std::runtime_error("OpenSSLCertificateVerifier::create");
+        return std::shared_ptr<V>(std::move(ret));
+    } else {
+        if (store)
+            return std::make_shared<V>(fizz::VerificationContext::Client,
+                                       std::move(store));
+        return std::make_shared<V>(fizz::VerificationContext::Client);
+    }
+}
+} // namespace
 #include <fizz/protocol/CertificateVerifier.h>
 #include <fizz/server/DefaultCertManager.h>
 #include <fizz/server/FizzServerContext.h>
@@ -262,7 +299,14 @@ struct moq_mvfst_managed {
     moq_version_t cfg_version = MOQ_VERSION_DRAFT_16;
     std::atomic<int> negotiated{0};
 
-    std::atomic<moq_session_t *> session{nullptr};
+    std::atomic<moq_session_t *> session{nullptr};   /* client session; freed
+                                                       * by the destructor,
+                                                       * after the thread is
+                                                       * joined */
+    ~moq_mvfst_managed() {
+        moq_session_t *s = session.exchange(nullptr);
+        if (s) moq_session_destroy(s);
+    }
     moq_perspective_t perspective = MOQ_PERSPECTIVE_CLIENT;
 
     struct start_cb
@@ -875,8 +919,17 @@ moq_result_t moq_mvfst_managed_create(
         if (h->transport) {
             h->transport.reset();
         }
-        moq_session_t *s = h->session.exchange(nullptr);
-        if (s) moq_session_destroy(s);
+        /* The client session is NOT destroyed here. It outlives the network
+         * thread until moq_mvfst_managed_destroy(), as it does on the
+         * picoquic facades: the service tier's media sender keeps a pointer
+         * to it and, once the endpoint is terminal, runs moq_pub_destroy()
+         * inline on the application thread (sender_destroy_pub_task cannot be
+         * posted to a dead pump). Freeing the session on a fatal loop exit
+         * left that destroy dereferencing freed memory (segfault in
+         * track_hist_release after a relay closed a draft-18 session). Nothing
+         * on this thread touches the session after adapter_ptr is gone, and
+         * moq_mvfst_managed_session() only hands it out inside the pump
+         * window. */
         if (auto *sevb = h->server_evb.load(std::memory_order_acquire)) {
             /* Barrier on server_evb: any in-flight pump callback has already
              * completed (FIFO), and scheduling is gated off, so it is safe to
@@ -1025,14 +1078,9 @@ moq_result_t moq_mvfst_managed_create(
                                     "load CA file");
                             X509_STORE_set_flags(store.get(),
                                 X509_V_FLAG_PARTIAL_CHAIN);
-                            chain = std::make_shared<fizz::openssl::
-                                OpenSSLCertificateVerifier>(
-                                    fizz::VerificationContext::Client,
-                                    std::move(store));
+                            chain = make_chain_verifier(std::move(store));
                         } else {
-                            chain = std::make_shared<fizz::openssl::
-                                OpenSSLCertificateVerifier>(
-                                    fizz::VerificationContext::Client);
+                            chain = make_chain_verifier(nullptr);
                         }
                         verifier = std::make_shared<identity_verifier>(
                             std::move(chain), server_name);
@@ -1053,6 +1101,17 @@ moq_result_t moq_mvfst_managed_create(
                         static_cast<uint16_t>(m->port), true);
                     m->transport->addNewPeerAddress(peer);
                     m->transport->setHostname(server_name);  /* SNI */
+                    /* Offer standard QUIC v1 only. mvfst's client default
+                     * puts Meta's private QuicVersion::MVFST (0xfaceb002)
+                     * first, and on the Version Negotiation packet every
+                     * non-mvfst server answers with (picoquic, quiche,
+                     * msquic) it fails the connection with
+                     * LocalErrorCode::NEW_VERSION_NEGOTIATED instead of
+                     * retrying -- so this client could only ever reach an
+                     * mvfst server. moxygen's own clients pin QUIC_V1 the
+                     * same way. */
+                    m->transport->setSupportedVersions(
+                        {quic::QuicVersion::QUIC_V1});
 
                     auto ts =
                         m->transport->getTransportSettings();

--- a/core/src/session/profile_d16.c
+++ b/core/src/session/profile_d16.c
@@ -38,6 +38,7 @@
  */
 
 #include "session_internal.h"
+#include "request_id_window.h"
 #include "../wire/control_d16_internal.h"
 #include "moq/control.h"
 
@@ -48,7 +49,10 @@
 typedef struct moq_d16_profile_state {
     moq_version_t version;
     uint64_t      next_local_request_id;
-    uint64_t      peer_next_request_id;
+    /* Peer request ids: high-water mark + not-yet-seen ids below it. Requests
+     * on the control stream arrive in order, but PUBLISH_NAMESPACE / PUBLISH /
+     * FETCH on their own bidi streams can overtake each other. */
+    moq_request_id_window_t peer_requests;
     uint64_t      requests_blocked_at;
     uint64_t      next_track_alias;
     bool          request_was_blocked;
@@ -78,8 +82,8 @@ static void d16_init_in_place(void *state, const moq_session_cfg_t *cfg)
 
     d16->next_local_request_id =
         (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 0 : 1;
-    d16->peer_next_request_id =
-        (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 1 : 0;
+    moq_request_id_window_init(&d16->peer_requests,
+        (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 1 : 0);
     d16->requests_blocked_at = UINT64_MAX;
     d16->request_was_blocked = false;
     d16->next_track_alias = 1;
@@ -3135,8 +3139,15 @@ static moq_result_t d16_validate_inbound_request(moq_session_t *s,
     uint64_t expected_parity = peer_is_client ? 0 : 1;
     if ((wire_request_id & 1) != expected_parity)
         return close_with_error(s, 0x4, "wrong request ID parity");
-    if (wire_request_id != d16->peer_next_request_id)
-        return close_with_error(s, 0x4, "request ID not next in sequence");
+    switch (moq_request_id_window_classify(&d16->peer_requests,
+                                           wire_request_id)) {
+    case MOQ_REQUEST_ID_NEW: break;
+    case MOQ_REQUEST_ID_DUPLICATE:
+        return close_with_error(s, 0x4, "duplicate request ID");
+    case MOQ_REQUEST_ID_TOO_FAR_AHEAD:
+        return close_with_error(s, 0x4, "request ID too far ahead of the "
+                                        "lowest outstanding request");
+    }
     uint64_t local_max = s->local_setup.has_max_request_id ?
         s->local_setup.max_request_id : 0;
     if (wire_request_id >= local_max)
@@ -3153,8 +3164,7 @@ static void d16_commit_inbound_request(moq_session_t *s,
 {
     moq_d16_profile_state_t *d16 =
         (moq_d16_profile_state_t *)s->profile_state;
-    (void)ep;
-    d16->peer_next_request_id += 2;
+    moq_request_id_window_commit(&d16->peer_requests, ep->request_id);
 }
 
 static void d16_release_request(moq_session_t *s,

--- a/core/src/session/profile_d18.c
+++ b/core/src/session/profile_d18.c
@@ -10,6 +10,7 @@
  */
 
 #include "session_internal.h"
+#include "request_id_window.h"
 #include "moq/control_d18.h"
 #include "../wire/control_d18_internal.h"
 #include "moq/vi64.h"
@@ -23,7 +24,9 @@ typedef struct moq_d18_profile_state {
     /* Request IDs are parity-allocated (client even, server odd). Draft-18 has
      * no MAX_REQUEST_ID; QUIC stream limits provide flow control. */
     uint64_t      next_local_request_id;
-    uint64_t      peer_next_request_id;
+    /* Peer request ids: high-water mark + not-yet-seen ids below it; requests
+     * ride their own bidi streams and can arrive out of order. */
+    moq_request_id_window_t peer_requests;
     uint64_t      next_track_alias;
 } moq_d18_profile_state_t;
 
@@ -34,8 +37,8 @@ static void d18_init_in_place(void *profile_state, const moq_session_cfg_t *cfg)
     d18->version = MOQ_VERSION_DRAFT_18;
     d18->next_local_request_id =
         (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 0 : 1;
-    d18->peer_next_request_id =
-        (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 1 : 0;
+    moq_request_id_window_init(&d18->peer_requests,
+        (cfg->perspective == MOQ_PERSPECTIVE_CLIENT) ? 1 : 0);
     d18->next_track_alias = 1;
 }
 
@@ -457,8 +460,17 @@ static moq_result_t d18_validate_inbound_request_stream(
     uint64_t expected_parity = peer_is_client ? 0 : 1;
     if ((wire_request_id & 1) != expected_parity)
         return close_with_error(s, 0x4, "wrong request ID parity");
-    if (wire_request_id != d18->peer_next_request_id)
-        return close_with_error(s, 0x4, "request ID not next in sequence");
+    /* Only parity and duplicates are errors (section 10.1): each request has
+     * its own stream, so ids can arrive out of order. */
+    switch (moq_request_id_window_classify(&d18->peer_requests,
+                                           wire_request_id)) {
+    case MOQ_REQUEST_ID_NEW: break;
+    case MOQ_REQUEST_ID_DUPLICATE:
+        return close_with_error(s, 0x4, "duplicate request ID");
+    case MOQ_REQUEST_ID_TOO_FAR_AHEAD:
+        return close_with_error(s, 0x4, "request ID too far ahead of the "
+                                        "lowest outstanding request");
+    }
     memset(out, 0, sizeof(*out));
     out->has_request_id = true;
     out->request_id = wire_request_id;
@@ -470,9 +482,8 @@ static moq_result_t d18_validate_inbound_request_stream(
 static void d18_commit_inbound_request(moq_session_t *s,
                                        const struct moq_request_endpoint *ep)
 {
-    (void)ep;
     moq_d18_profile_state_t *d18 = (moq_d18_profile_state_t *)s->profile_state;
-    d18->peer_next_request_id += 2;
+    moq_request_id_window_commit(&d18->peer_requests, ep->request_id);
 }
 
 /* Map the representable SUBSCRIBE/FETCH settings onto draft-18 Message
@@ -2927,7 +2938,7 @@ static moq_result_t d18_encode_goaway(moq_session_t *s,
         (const moq_d18_profile_state_t *)s->profile_state;
     uint64_t timeout_ms = s->goaway_timeout_us / 1000;
     return moq_d18_encode_goaway(w, args->uri, args->uri_len, timeout_ms,
-                                 d18->peer_next_request_id);
+                                 d18->peer_requests.next);
 }
 
 /* -- Vtable -------------------------------------------------------- *

--- a/core/src/session/request_id_window.h
+++ b/core/src/session/request_id_window.h
@@ -1,0 +1,88 @@
+/*
+ * Inbound peer Request ID tracking shared by the draft-16 and draft-18 profiles.
+ *
+ * The peer allocates its Request IDs sequentially with its parity (draft-18
+ * section 10.1, draft-16 section 9.5), but from draft-16 on a request can ride
+ * its own bidirectional stream, and streams carry no ordering guarantee between
+ * them: a transport that services stream 9 before stream 5 delivers request 5
+ * before request 3 (mvfst does; picoquic happens to serve lower ids first). The
+ * draft makes only a wrong parity or a DUPLICATE id a session error
+ * (INVALID_REQUEST_ID), so the receiver must tolerate arrival out of order.
+ *
+ * The tracker keeps a high-water mark `next` (the lowest id above every id seen
+ * so far, which is also what GOAWAY reports as the next unprocessed request)
+ * plus the set of ids below it that have not arrived yet. An id at the mark
+ * advances it; one above it records the skipped ids as gaps and jumps; one
+ * below it must be an open gap, otherwise it is a duplicate. The gap set is
+ * bounded: a peer that runs more than MOQ_REQUEST_ID_GAP_MAX requests ahead of
+ * its lowest outstanding one is refused as a protocol error, which keeps the
+ * per-session cost fixed and still far exceeds any real request window.
+ */
+#ifndef MOQ_REQUEST_ID_WINDOW_H
+#define MOQ_REQUEST_ID_WINDOW_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef MOQ_REQUEST_ID_GAP_MAX
+#define MOQ_REQUEST_ID_GAP_MAX 64
+#endif
+
+typedef struct moq_request_id_window {
+    uint64_t next;                            /* high-water mark (peer parity) */
+    uint64_t gaps[MOQ_REQUEST_ID_GAP_MAX];    /* ids < next not yet received */
+    size_t   gap_count;
+} moq_request_id_window_t;
+
+/* Classification of an inbound id whose parity already matched the peer's. */
+typedef enum moq_request_id_verdict {
+    MOQ_REQUEST_ID_NEW = 0,       /* not seen before: accept */
+    MOQ_REQUEST_ID_DUPLICATE,     /* already received (or below the lowest gap) */
+    MOQ_REQUEST_ID_TOO_FAR_AHEAD  /* would leave more than MOQ_REQUEST_ID_GAP_MAX
+                                     ids outstanding below the mark */
+} moq_request_id_verdict_t;
+
+static inline void moq_request_id_window_init(moq_request_id_window_t *w,
+                                              uint64_t first_peer_id)
+{
+    w->next = first_peer_id;
+    w->gap_count = 0;
+}
+
+/* Pure: classify without recording. Validation and commit are separate steps
+ * in the profiles (a request can still be refused after validation). */
+static inline moq_request_id_verdict_t
+moq_request_id_window_classify(const moq_request_id_window_t *w, uint64_t id)
+{
+    if (id == w->next) return MOQ_REQUEST_ID_NEW;
+    if (id > w->next) {
+        uint64_t skipped = (id - w->next) / 2;
+        return (skipped <= MOQ_REQUEST_ID_GAP_MAX &&
+                w->gap_count + (size_t)skipped <= MOQ_REQUEST_ID_GAP_MAX)
+                   ? MOQ_REQUEST_ID_NEW : MOQ_REQUEST_ID_TOO_FAR_AHEAD;
+    }
+    for (size_t i = 0; i < w->gap_count; i++)
+        if (w->gaps[i] == id) return MOQ_REQUEST_ID_NEW;
+    return MOQ_REQUEST_ID_DUPLICATE;
+}
+
+/* Record an id that classified as NEW. */
+static inline void moq_request_id_window_commit(moq_request_id_window_t *w,
+                                                uint64_t id)
+{
+    if (id == w->next) { w->next += 2; return; }
+    if (id > w->next) {
+        for (uint64_t x = w->next; x < id; x += 2)
+            w->gaps[w->gap_count++] = x;   /* bounded by classify() */
+        w->next = id + 2;
+        return;
+    }
+    for (size_t i = 0; i < w->gap_count; i++) {
+        if (w->gaps[i] == id) {
+            w->gaps[i] = w->gaps[--w->gap_count];   /* order is irrelevant */
+            return;
+        }
+    }
+}
+
+#endif /* MOQ_REQUEST_ID_WINDOW_H */

--- a/docs/mvfst-managed-client.md
+++ b/docs/mvfst-managed-client.md
@@ -89,10 +89,10 @@ callback fires.
 |----------|--------|-------|
 | `create` | app | Spawns thread, blocks until init succeeds/fails |
 | `stop` | app | Joins thread, idempotent. Returns `MOQ_ERR_INVAL` if called from pump |
-| `destroy` | app | Calls `stop()` internally. `destroy(NULL)` is no-op |
+| `destroy` | app | Calls `stop()` internally, then frees the client session. `destroy(NULL)` is no-op |
 | `wake` | any | Thread-safe, coalesced |
 | `wait` | app | Returns `MOQ_OK` (activity), `MOQ_DONE` (timeout), `MOQ_ERR_CLOSED` |
-| `session` | pump | Returns NULL from wrong thread or after stop |
+| `session` | pump | Returns NULL from wrong thread or after stop (the session object itself stays allocated until `destroy`, so a service-tier consumer can still tear down after a fatal) |
 | `is_fatal` | any | Atomic read |
 | `fatal_code` | any | Atomic read |
 
@@ -151,9 +151,17 @@ The mvfst adapter is optional and does not affect normal libmoq
 builds:
 
 ```sh
-cmake -B build -DMOQ_BUILD_ADAPTER_MVFST=ON
+cmake -B build -DMOQ_BUILD_ADAPTER_MVFST=ON \
+    -DMOQ_MVFST_PREFIX=/prefix -DMOQ_FIZZ_PREFIX=/prefix -DMOQ_FOLLY_PREFIX=/prefix
 cmake --build build
 ```
+
+The prefix must also provide `fmt`'s CMake package: folly's config references
+`fmt::fmt` without finding it, so the adapter's CMake finds fmt before mvfst.
+The client offers QUIC v1 only (`QuicVersion::QUIC_V1`): mvfst's default
+offers Meta's private `MVFST` version first and treats the Version
+Negotiation packet every other QUIC server answers with as a fatal error, so
+without the pin the client could only reach an mvfst server.
 
 The mvfst adapter is consumed via CMake components:
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -641,6 +641,29 @@ if(MOQ_BUILD_TESTS)
         set_tests_properties(endpoint_lifecycle PROPERTIES
             LABELS "network" TIMEOUT 60 RESOURCE_LOCK service_network)
 
+        # mvfst backend: a media sender attached to an endpoint that went
+        # terminal must still be destroyable (the facade used to free the
+        # session on its fatal loop exit; the sender's inline moq_pub_destroy
+        # then read freed memory). Skips (77) when mvfst is not built.
+        if(MOQ_BUILD_ADAPTER_MVFST AND MOQ_BUILD_PQ_THREADED)
+            add_executable(test_endpoint_mvfst_fatal_teardown
+                tests/test_endpoint_mvfst_fatal_teardown.c)
+            target_link_libraries(test_endpoint_mvfst_fatal_teardown PRIVATE
+                moq::service moq::adapter-mvfst moq::adapter-picoquic-threaded
+                Threads::Threads)
+            target_compile_definitions(test_endpoint_mvfst_fatal_teardown PRIVATE
+                ${_MOQ_SERVICE_FACADE_DEFS})
+            target_include_directories(test_endpoint_mvfst_fatal_teardown PRIVATE
+                ${CMAKE_SOURCE_DIR}/tests/unit)
+            add_test(NAME endpoint_mvfst_fatal_teardown
+                COMMAND test_endpoint_mvfst_fatal_teardown
+                    --cert "${MOQ_PICOQUIC_SOURCE_DIR}/certs/cert.pem"
+                    --key "${MOQ_PICOQUIC_SOURCE_DIR}/certs/key.pem")
+            set_tests_properties(endpoint_mvfst_fatal_teardown PROPERTIES
+                LABELS "network" TIMEOUT 90 RESOURCE_LOCK service_network
+                SKIP_RETURN_CODE 77)
+        endif()
+
         # Idle managed-loopback discriminator for automatic catalog refresh:
         # a media_sender over a REAL pq_threaded endpoint whose catalog group
         # advances while idle only if the adapter wakes itself at the refresh

--- a/service/tests/test_endpoint_mvfst_fatal_teardown.c
+++ b/service/tests/test_endpoint_mvfst_fatal_teardown.c
@@ -1,0 +1,191 @@
+/*
+ * mvfst backend: the client session outlives a fatal loop exit until the
+ * endpoint is destroyed, so a media sender still attached to it can be torn
+ * down afterwards.
+ *
+ * Reproduces the moqxr crash against red5-moq-relay: the relay closed the
+ * session, the mvfst facade's network thread destroyed the MoQ session on its
+ * way out, and moq_media_sender_destroy() (which runs moq_pub_destroy() inline
+ * once the endpoint is terminal -- nothing can be posted to a dead pump)
+ * dereferenced the freed session in track_hist_release. The picoquic facades
+ * keep the session until destroy(); the mvfst facade now does the same.
+ *
+ * Shape: a loopback picoquic threaded server accepts the mvfst client, the
+ * sender announces its namespace and a track (which reserves session-owned
+ * history), then the server closes the connection with an application error.
+ * The client goes terminal; the sender is destroyed in the documented order
+ * (sender, then endpoint stop/destroy). Under ASan the old facade reports a
+ * heap-use-after-free in moq_pub_destroy. Args: --cert <file> --key <file>.
+ */
+#include <moq/endpoint.h>
+#include <moq/media_sender.h>
+#include <moq/picoquic_threaded.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test_support.h"
+
+#ifdef MOQ_SERVICE_HAVE_MVFST_MANAGED
+
+typedef struct {
+    uint64_t accepted_at_us;   /* first pump that saw a connection */
+    int      closed;           /* close issued */
+} server_ctx_t;
+
+/* Close the (single) accepted connection about a second after it appeared:
+ * long enough for SETUP, PUBLISH_NAMESPACE and the track registration. */
+static int server_pump(moq_pq_threaded_t *t, moq_pq_threaded_lane_t *lane,
+                       uint64_t now_us, void *ctx)
+{
+    (void)t;
+    server_ctx_t *sc = (server_ctx_t *)ctx;
+    moq_pq_threaded_conn_t *c = NULL;
+    while ((c = moq_pq_threaded_lane_next_conn(lane, c)) != NULL) {
+        if (sc->accepted_at_us == 0) sc->accepted_at_us = now_us;
+        if (!sc->closed && now_us - sc->accepted_at_us > 1000000) {
+            sc->closed = 1;
+            (void)moq_pq_threaded_conn_close(c, 0x10);
+        }
+    }
+    return 0;
+}
+
+static moq_pq_threaded_t *start_server(const char *cert, const char *key,
+                                       server_ctx_t *sc, int *out_port)
+{
+    int base = 15300 + (int)(getpid() % 997);
+    for (int attempt = 0; attempt < 8; attempt++) {
+        int port = base + attempt * 17;
+        moq_pq_threaded_cfg_t cfg;
+        moq_pq_threaded_cfg_init(&cfg);
+        cfg.alloc = moq_alloc_default();
+        cfg.perspective = MOQ_PERSPECTIVE_SERVER;
+        cfg.cert_path = cert;
+        cfg.key_path = key;
+        cfg.port = port;
+        cfg.send_request_capacity = true;
+        cfg.initial_request_capacity = 16;
+        cfg.on_lane_pump = server_pump;
+        cfg.on_lane_pump_ctx = sc;
+        moq_pq_threaded_t *srv = NULL;
+        if (moq_pq_threaded_create(&cfg, &srv) == MOQ_OK) {
+            *out_port = port;
+            return srv;
+        }
+    }
+    return NULL;
+}
+
+static int run(const char *cert, const char *key)
+{
+    int failures = 0;
+    server_ctx_t sc; memset(&sc, 0, sizeof(sc));
+    int port = 0;
+    moq_pq_threaded_t *srv = start_server(cert, key, &sc, &port);
+    MOQ_TEST_CHECK(srv != NULL);
+    if (!srv) return failures;
+    for (int i = 0; i < 3; i++) moq_pq_threaded_wait(srv, 100000);
+
+    char url[64];
+    snprintf(url, sizeof(url), "moqt://127.0.0.1:%d", port);
+    moq_endpoint_cfg_t cfg;
+    moq_endpoint_cfg_init(&cfg);
+    cfg.url = (moq_bytes_t){(const uint8_t *)url, strlen(url)};
+    cfg.protocol = MOQ_TRANSPORT_PROTOCOL_RAW_QUIC;
+    cfg.backend = MOQ_TRANSPORT_BACKEND_MVFST;
+    moq_version_t v[1] = {MOQ_VERSION_DRAFT_16};
+    cfg.versions.struct_size = sizeof(cfg.versions);
+    cfg.versions.policy = MOQ_VERSION_POLICY_EXACT;   /* mvfst: exact only */
+    cfg.versions.versions = v;
+    cfg.versions.version_count = 1;
+    cfg.insecure_skip_verify = true;                  /* self-signed loopback */
+
+    moq_endpoint_t *ep = NULL;
+    MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_connect(&cfg, &ep), (int)MOQ_OK);
+    if (!ep) { moq_pq_threaded_stop(srv); moq_pq_threaded_destroy(srv); return failures + 1; }
+
+    static const moq_bytes_t ns_parts[] = {
+        {(const uint8_t *)"mvfst", 5}, {(const uint8_t *)"fatal", 5}};
+    moq_media_sender_cfg_t scfg;
+    moq_media_sender_cfg_init_live(&scfg);
+    scfg.namespace_ = (moq_namespace_t){ns_parts, 2};
+    moq_media_sender_t *tx = NULL;
+    MOQ_TEST_CHECK_EQ_INT((int)moq_media_sender_attach(ep, &scfg, &tx), (int)MOQ_OK);
+
+    /* The track's largest-location history record is reserved in the session
+     * registry at add_track; releasing it is what the crash dereferenced. */
+    moq_media_track_t *track = NULL;
+    if (tx) {
+        moq_media_track_cfg_t tcfg;
+        moq_media_track_cfg_init(&tcfg);
+        tcfg.name = (moq_bytes_t){(const uint8_t *)"vide_1", 6};
+        tcfg.media_type = MOQ_MEDIA_TYPE_VIDEO;
+        tcfg.packaging = MOQ_MEDIA_PACKAGING_CMAF;
+        tcfg.codec = (moq_bytes_t){(const uint8_t *)"avc1.64000D", 11};
+        tcfg.timescale = 1000000;
+        tcfg.bitrate = 500000;
+        tcfg.width = 320;
+        tcfg.height = 240;
+        MOQ_TEST_CHECK_EQ_INT((int)moq_media_sender_add_track(tx, &tcfg, &track),
+                              (int)MOQ_OK);
+    }
+
+    /* Established first (the server accepted us), then terminal (it closed). */
+    int established = 0, terminal = 0;
+    for (int i = 0; i < 100 && !established; i++) {
+        (void)moq_endpoint_wait(ep, 100000);
+        established = moq_endpoint_state(ep) == MOQ_ENDPOINT_ESTABLISHED;
+        if (moq_endpoint_is_fatal(ep)) break;
+    }
+    if (!established) {
+        moq_endpoint_terminal_t t; memset(&t, 0, sizeof t);
+        moq_endpoint_get_terminal(ep, &t, sizeof t);
+        fprintf(stderr, "not established: state=%d fatal=%d code=0x%llx reason=%d detail=0x%llx\n",
+                (int)moq_endpoint_state(ep), moq_endpoint_is_fatal(ep),
+                (unsigned long long)moq_endpoint_fatal_code(ep), (int)t.reason,
+                (unsigned long long)t.detail_code);
+    }
+    MOQ_TEST_CHECK(established);
+    for (int i = 0; i < 150 && !terminal; i++) {
+        (void)moq_endpoint_wait(ep, 100000);
+        terminal = moq_endpoint_is_fatal(ep) || moq_endpoint_is_closed(ep) ||
+                   moq_endpoint_state(ep) == MOQ_ENDPOINT_CLOSED;
+    }
+    MOQ_TEST_CHECK(terminal);
+    MOQ_TEST_CHECK(sc.closed);
+
+    /* The crash site. */
+    if (tx) moq_media_sender_destroy(tx);
+    MOQ_TEST_CHECK_EQ_INT((int)moq_endpoint_stop(ep), (int)MOQ_OK);
+    moq_endpoint_destroy(ep);
+
+    moq_pq_threaded_stop(srv);
+    moq_pq_threaded_destroy(srv);
+    return failures;
+}
+#endif
+
+int main(int argc, char **argv)
+{
+#ifndef MOQ_SERVICE_HAVE_MVFST_MANAGED
+    (void)argc; (void)argv;
+    fprintf(stderr, "mvfst backend not built; skipping\n");
+    return 77;
+#else
+    const char *cert = NULL, *key = NULL;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--cert") && i + 1 < argc) cert = argv[++i];
+        else if (!strcmp(argv[i], "--key") && i + 1 < argc) key = argv[++i];
+    }
+    if (!cert || !key) {
+        fprintf(stderr, "usage: %s --cert <file> --key <file>\n", argv[0]);
+        return 2;
+    }
+    int failures = run(cert, key);
+    if (failures) return failures;
+    MOQ_TEST_PASS("test_endpoint_mvfst_fatal_teardown");
+    return 0;
+#endif
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,10 @@ add_executable(test_bytes unit/test_bytes.c)
 target_link_libraries(test_bytes PRIVATE moq::core)
 add_test(NAME bytes COMMAND test_bytes)
 
+add_executable(test_request_id_window unit/test_request_id_window.c)
+target_link_libraries(test_request_id_window PRIVATE moq::core)
+add_test(NAME request_id_window COMMAND test_request_id_window)
+
 add_executable(test_quic_varint unit/test_quic_varint.c)
 target_link_libraries(test_quic_varint PRIVATE moq::core)
 add_test(NAME quic_varint COMMAND test_quic_varint)

--- a/tests/unit/test_request_id_window.c
+++ b/tests/unit/test_request_id_window.c
@@ -1,0 +1,69 @@
+/*
+ * Peer Request ID tracking (core/src/session/request_id_window.h): requests on
+ * separate bidi streams can arrive out of order, and only a wrong parity or a
+ * duplicate is an error (draft-18 section 10.1). Reproduces the red5-moq-relay
+ * over mvfst case: the relay's SUBSCRIBEs 3 and 5 on streams 5 and 9, with
+ * mvfst servicing stream 9 first.
+ */
+#include "../../core/src/session/request_id_window.h"
+#include "test_support.h"
+
+int main(void)
+{
+    int failures = 0;
+    moq_request_id_window_t w;
+
+    /* In order: 1, 3, 5 (a client tracking a server's odd ids). */
+    moq_request_id_window_init(&w, 1);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 1) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, 1);
+    MOQ_TEST_CHECK(w.next == 3 && w.gap_count == 0);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 3) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, 3);
+    MOQ_TEST_CHECK(w.next == 5);
+
+    /* Out of order: 5 arrives before 3 (streams reordered by the transport). */
+    moq_request_id_window_init(&w, 1);
+    moq_request_id_window_commit(&w, 1);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 5) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, 5);
+    MOQ_TEST_CHECK(w.next == 7);               /* GOAWAY reports 7 as next */
+    MOQ_TEST_CHECK(w.gap_count == 1 && w.gaps[0] == 3);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 3) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, 3);
+    MOQ_TEST_CHECK(w.gap_count == 0 && w.next == 7);
+
+    /* Duplicates: an id already committed, at or below the mark. */
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 3) == MOQ_REQUEST_ID_DUPLICATE);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 5) == MOQ_REQUEST_ID_DUPLICATE);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 1) == MOQ_REQUEST_ID_DUPLICATE);
+    /* A gap that is still open is not a duplicate; once filled it is. */
+    moq_request_id_window_commit(&w, 11);      /* gaps 7, 9 */
+    MOQ_TEST_CHECK(w.gap_count == 2);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 9) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, 9);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 9) == MOQ_REQUEST_ID_DUPLICATE);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, 7) == MOQ_REQUEST_ID_NEW);
+
+    /* Classification is pure: nothing moved until commit. */
+    moq_request_id_window_t before = w;
+    (void)moq_request_id_window_classify(&w, 13);
+    MOQ_TEST_CHECK(before.next == w.next && before.gap_count == w.gap_count);
+
+    /* Bounded gap set: running MOQ_REQUEST_ID_GAP_MAX ahead is allowed, one
+     * more is refused, and the refusal does not change the window. */
+    moq_request_id_window_init(&w, 0);
+    uint64_t far = 2 * (uint64_t)MOQ_REQUEST_ID_GAP_MAX;   /* leaves exactly MAX gaps */
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, far) == MOQ_REQUEST_ID_NEW);
+    moq_request_id_window_commit(&w, far);
+    MOQ_TEST_CHECK(w.gap_count == (size_t)MOQ_REQUEST_ID_GAP_MAX);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, far + 2) == MOQ_REQUEST_ID_NEW);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, far + 4) == MOQ_REQUEST_ID_TOO_FAR_AHEAD);
+    MOQ_TEST_CHECK(w.gap_count == (size_t)MOQ_REQUEST_ID_GAP_MAX && w.next == far + 2);
+    /* Filling a gap frees room again. */
+    moq_request_id_window_commit(&w, 0);
+    MOQ_TEST_CHECK(moq_request_id_window_classify(&w, far + 4) == MOQ_REQUEST_ID_NEW);
+
+    MOQ_TEST_PASS("test_request_id_window");
+    return failures;
+}

--- a/tests/unit/test_session_namespace_sub.c
+++ b/tests/unit/test_session_namespace_sub.c
@@ -1451,19 +1451,25 @@ int main(void)
         MOQ_TEST_CHECK(as.balance == 0);
     }
 
-    /* == 19. Request-ID out of sequence → close ======================== */
+    /* == 19. Request-ID out of order is accepted; a duplicate closes ==== */
+    /* Each request rides its own bidi stream, and streams reorder; only wrong
+     * parity and duplicates are INVALID_REQUEST_ID (draft-18 section 10.1). */
     {
         test_alloc_state_t as = {0};
         moq_alloc_t alloc = test_allocator(&as);
         moq_session_t *c = NULL, *sv = NULL;
         establish_pair(&alloc, 64, 64, &c, &sv, NULL, NULL);
 
-        /* Server expects next peer request_id=0; send 2 (skips 0). */
+        /* Server expects next peer request_id=0; 2 arrives first (skips 0). */
         uint8_t msg[256];
         size_t msg_len = encode_sub_ns_raw(msg, sizeof(msg), 2, "seq", 0);
         moq_stream_ref_t ref = moq_stream_ref_from_u64(1500);
-
         moq_session_on_bidi_stream_bytes(sv, ref, msg, msg_len, false, 0);
+        MOQ_TEST_CHECK(moq_session_state(sv) != MOQ_SESS_CLOSED);
+
+        /* The same id again on another stream is the duplicate case. */
+        moq_stream_ref_t ref2 = moq_stream_ref_from_u64(1504);
+        moq_session_on_bidi_stream_bytes(sv, ref2, msg, msg_len, false, 0);
         MOQ_TEST_CHECK(moq_session_state(sv) == MOQ_SESS_CLOSED);
 
         DRAIN_BOTH(c, sv);

--- a/tests/unit/test_session_subscribe.c
+++ b/tests/unit/test_session_subscribe.c
@@ -751,18 +751,30 @@ int main(void)
         MOQ_TEST_CHECK(as.balance == 0);
     }
 
-    /* -- Non-next request ID → INVALID_REQUEST_ID (0x4) -------------- */
+    /* -- Skipped request ID is accepted; a duplicate closes (0x4) ----- */
+    /* Requests on separate bidi streams can arrive out of order, so a peer
+     * id ahead of the next expected one is not an error (draft-18 section
+     * 10.1 names only wrong parity and duplicates). The skipped id may still
+     * arrive later; the same id twice is the INVALID_REQUEST_ID case. */
     {
         test_alloc_state_t as = {0};
         moq_alloc_t alloc = test_allocator(&as);
         moq_session_t *c = NULL, *sv = NULL;
         establish_pair(&alloc, 10, 10, &c, &sv, NULL, NULL);
 
-        feed_subscribe(sv, 2, "ns", "t", NULL, 0);
+        feed_subscribe(sv, 2, "ns", "t", NULL, 0);     /* skips 0 */
+        MOQ_TEST_CHECK(moq_session_state(sv) != MOQ_SESS_CLOSED);
+        feed_subscribe(sv, 0, "ns", "t0", NULL, 0);    /* the gap fills */
+        MOQ_TEST_CHECK(moq_session_state(sv) != MOQ_SESS_CLOSED);
+        feed_subscribe(sv, 2, "ns", "t", NULL, 0);     /* duplicate */
         MOQ_TEST_CHECK(moq_session_state(sv) == MOQ_SESS_CLOSED);
         moq_event_t ev;
-        moq_session_poll_events(sv, &ev, 1);
-        MOQ_TEST_CHECK(ev.u.closed.code == 0x4);
+        uint64_t closed_code = 0;
+        while (moq_session_poll_events(sv, &ev, 1) > 0) {
+            if (ev.kind == MOQ_EVENT_SESSION_CLOSED) closed_code = ev.u.closed.code;
+            moq_event_cleanup(&ev);
+        }
+        MOQ_TEST_CHECK(closed_code == 0x4);
 
         moq_session_destroy(c);
         moq_session_destroy(sv);


### PR DESCRIPTION
Closes #20, closes #21, closes #22, closes #23.

Found by driving moqxr's libmoq publish backend through the mvfst adapter (openmoq/moqxr#33) to red5-moq-relay 1.6.44 at `moq-relay.red5.net:4433` over raw QUIC, drafts 16 and 18. Before this branch the adapter did not build against a current mvfst/fizz/folly prefix, and once it did the client could not reach the relay at all; with the branch the same runs deliver 200+ media objects to a playa subscriber on both drafts. Independent of #19 (branch is off `main`).

## Commits

**Accept out-of-order peer request IDs on draft-16/18 request streams (#22).** Both profiles closed with 0x4 unless each inbound request id was exactly the next expected one. Requests ride their own bidi streams from draft-16 on, and streams reorder: the relay opened its two media SUBSCRIBE streams in the same millisecond and mvfst serviced stream 9 (request 5) before stream 5 (request 3); picoquic happened to serve lower ids first. Draft-18 section 10.1 names only wrong parity and duplicates as errors. New `request_id_window.h` keeps a high-water mark (still what GOAWAY reports) plus the not-yet-seen ids below it, bounded at 64 gaps; validation stays pure, commit records. The two unit tests that asserted the strict close now assert the draft's contract; `test_request_id_window` covers ordering, gaps, duplicates and the bound.

**mvfst adapter: build against current fizz/folly, offer QUIC v1, keep the session until destroy (#20, #21, #23).**
- fmt is found before mvfst (folly's config references `fmt::fmt` without finding it), and `make_chain_verifier()` uses fizz's `OpenSSLCertificateVerifier::create()` factory when present, falling back to the older public constructors.
- The client offers `QuicVersion::QUIC_V1` only: mvfst's default puts its private version first and fails the connection on the Version Negotiation packet every non-mvfst server sends, as moxygen's own clients already work around.
- The client session outlives a fatal loop exit until `moq_mvfst_managed_destroy()` (the destructor frees it), matching the picoquic facades. `test_endpoint_mvfst_fatal_teardown` (loopback picoquic threaded server closes the connection after the sender added a track) reports heap-use-after-free in `track_hist_release <- moq_pub_destroy <- moq_media_sender_destroy` under ASan on the previous facade and passes here.

## Tests

`ctest` on a tree with `MOQ_BUILD_ADAPTER_MVFST=ON` plus the picoquic adapters: all mvfst tests pass except `mvfst_c_consumer_build`, which fails identically on `main` here (the installed config cannot find mvfst; noted in #20). The full suite with the picoquic adapters (`build/dev`): 206 of 206 pass after the profile change (the five failures noted in #19 are excluded, they are unchanged and unrelated).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq5/24)
<!-- Reviewable:end -->
